### PR TITLE
Fix blueprint theme contact section frame layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -344,7 +344,6 @@
 
               <!-- CRO: Urgency Banner -->
               <div class="contact-urgency">
-                <span class="urgency-icon">&#9889;</span>
                 <span>Currently accepting new clients for Q1 2025</span>
               </div>
 
@@ -354,18 +353,18 @@
               </div>
               
               <!-- Blueprint SVG frame -->
-              <svg class="contact-blueprint-svg" viewBox="0 0 600 200">
-                <rect x="10" y="10" width="580" height="180" class="contact-border" rx="0"/>
-                <g class="corner-mark" transform="translate(10, 10)">
+              <svg class="contact-blueprint-svg" viewBox="0 0 600 200" preserveAspectRatio="none">
+                <rect x="5" y="5" width="590" height="190" class="contact-border" rx="0"/>
+                <g class="corner-mark" transform="translate(5, 5)">
                   <line x1="-10" y1="0" x2="20" y2="0"/><line x1="0" y1="-10" x2="0" y2="20"/>
                 </g>
-                <g class="corner-mark" transform="translate(590, 10)">
+                <g class="corner-mark" transform="translate(595, 5)">
                   <line x1="-20" y1="0" x2="10" y2="0"/><line x1="0" y1="-10" x2="0" y2="20"/>
                 </g>
-                <g class="corner-mark" transform="translate(10, 190)">
+                <g class="corner-mark" transform="translate(5, 195)">
                   <line x1="-10" y1="0" x2="20" y2="0"/><line x1="0" y1="-20" x2="0" y2="10"/>
                 </g>
-                <g class="corner-mark" transform="translate(590, 190)">
+                <g class="corner-mark" transform="translate(595, 195)">
                   <line x1="-20" y1="0" x2="10" y2="0"/><line x1="0" y1="-20" x2="0" y2="10"/>
                 </g>
               </svg>
@@ -379,7 +378,6 @@
 
               <!-- CRO: Response Time -->
               <div class="response-time">
-                <span class="response-icon">&#9200;</span>
                 <span>Typically responds within 24 hours</span>
               </div>
 

--- a/frontend/themes/blueprint/blueprint.css
+++ b/frontend/themes/blueprint/blueprint.css
@@ -10,12 +10,14 @@
   --bg-blueprint: #003366;
   --bg-blueprint-dark: #002244;
   --bg-blueprint-light: #004488;
-  
+
   /* Lines & Strokes */
   --line-white: rgba(255, 255, 255, 0.8);
   --line-white-dim: rgba(255, 255, 255, 0.3);
   --line-white-faint: rgba(255, 255, 255, 0.1);
-  
+
+  --primary: var(--line-white);
+
   /* Accents */
   --accent-redline: #FF3333;
   --accent-cyan: #00FFFF;
@@ -865,13 +867,29 @@ body[data-theme="blueprint"] .contact-card {
   display: inline-block;
   background: transparent;
   border: none;
-  padding: var(--spacing-lg) var(--spacing-xl);
 }
 
 body[data-theme="blueprint"] .contact-card .card-body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
+  z-index: 1;
+  padding: var(--spacing-lg) var(--spacing-xl);
+}
+
+/* Ensure CRO elements fit within the frame */
+body[data-theme="blueprint"] .availability-badge {
+  margin-bottom: var(--spacing-sm);
+}
+
+body[data-theme="blueprint"] .contact-urgency {
+  margin-bottom: var(--spacing-sm);
+}
+
+body[data-theme="blueprint"] .response-time {
+  margin-top: var(--spacing-xs);
+  margin-bottom: var(--spacing-xs);
 }
 
 /* Blueprint SVG Frame - positioned around the email */
@@ -883,6 +901,7 @@ body[data-theme="blueprint"] .contact-blueprint-svg {
   width: 100%;
   height: 100%;
   pointer-events: none;
+  overflow: visible;
 }
 
 body[data-theme="blueprint"] .contact-border {
@@ -943,7 +962,7 @@ body[data-theme="blueprint"] .email-link:hover .stamp {
 
 /* Social Links */
 body[data-theme="blueprint"] .social-links {
-  margin-top: var(--spacing-lg);
+  margin-top: var(--spacing-sm);
   display: flex;
   justify-content: center;
   gap: var(--spacing-md);


### PR DESCRIPTION
The availability badge and social links were overflowing outside the SVG frame box. Fixed by adding preserveAspectRatio="none" to stretch the SVG frame to contain all content, and adjusted margins/padding for CRO elements.