### PR TITLE
Rebrand from creative developer to product engineer

### DIFF
--- a/frontend/data/content.json
+++ b/frontend/data/content.json
@@ -1,20 +1,20 @@
 {
   "meta": {
     "name": "Tom Andrieu",
-    "title": "Creative Developer",
-    "description": "Full-stack creative developer crafting digital experiences with motion, interaction, and visual storytelling."
+    "title": "Product Engineer",
+    "description": "Product engineer who builds meaningful products, iterates with purpose, and helps teams do their best work."
   },
   "hero": {
-    "title": ["CREATIVE", "DEVELOPER"],
-    "subtitle": "BUILDING DIGITAL EXPERIENCES"
+    "title": ["PRODUCT", "ENGINEER"],
+    "subtitle": "BUILDING THINGS THAT MATTER"
   },
   "about": {
-    "intro": "I craft digital experiences with a focus on <highlight>MOTION</highlight>, <highlight>INTERACTION</highlight>, and <highlight>VISUAL STORYTELLING</highlight>.",
-    "detail": "With expertise spanning front-end development, UI/UX design, and creative coding, I transform complex ideas into elegant, functional solutions.",
+    "intro": "I build <highlight>MEANINGFUL</highlight> products and help small teams do their <highlight>BEST WORK</highlight>.",
+    "detail": "I care about craft and iteration. I'd rather enable others than micromanage them. Working with AI has made me even more optimistic about what focused teams can create.",
     "specs": {
       "location": "FRANCE",
       "experience": "7+ YEARS",
-      "focus": "FULL-STACK",
+      "focus": "PRODUCT ENGINEERING",
       "status": "AVAILABLE FOR PROJECTS"
     }
   },

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tom Andrieu - Creative Developer Portfolio</title>
-  <meta name="description" content="Full-stack creative developer crafting digital experiences with motion, interaction, and visual storytelling." />
+  <title>Tom Andrieu - Product Engineer</title>
+  <meta name="description" content="Product engineer who builds meaningful products, iterates with purpose, and helps teams do their best work." />
 
   <!-- PostHog Analytics -->
   <script>
@@ -245,20 +245,20 @@
           <span class="cursor-blink">_</span>
         </div>
         <div class="terminal-output">
-          <p class="output-line">[<span class="status-ok">OK</span>] Loading creative modules...</p>
-          <p class="output-line">[<span class="status-ok">OK</span>] Full-stack developer initialized</p>
-          <p class="output-line">[<span class="status-ok">OK</span>] Ready to build awesome stuff!</p>
+          <p class="output-line">[<span class="status-ok">OK</span>] Loading modules...</p>
+          <p class="output-line">[<span class="status-ok">OK</span>] Product engineer initialized</p>
+          <p class="output-line">[<span class="status-ok">OK</span>] Ready to build something meaningful</p>
         </div>
       </div>
 
       <h1 class="hero-title">
-        <span class="title-line" data-content="hero.title.0">CREATIVE</span>
-        <span class="title-line" data-content="hero.title.1">DEVELOPER</span>
+        <span class="title-line" data-content="hero.title.0">PRODUCT</span>
+        <span class="title-line" data-content="hero.title.1">ENGINEER</span>
       </h1>
 
       <p class="hero-subtitle" data-content="hero.subtitle">
         <span class="annotation-mark"></span>
-        BUILDING DIGITAL EXPERIENCES
+        BUILDING THINGS THAT MATTER
         <span class="annotation-mark"></span>
       </p>
 
@@ -276,8 +276,8 @@
           <span class="stat-value">[████████████████████] 100%</span>
         </div>
         <div class="stat-bar">
-          <span class="stat-label">COFFEE_LVL</span>
-          <span class="stat-value">[██████████████░░░░░░] 70%</span>
+          <span class="stat-label">DRIVE</span>
+          <span class="stat-value">[████████████████████] 100%</span>
         </div>
         <div class="stat-bar">
           <span class="stat-label">CODE_SKILL</span>
@@ -363,14 +363,13 @@
           <div class="about-text">
             <p class="code-comment">/* Who am I? */</p>
             <p class="about-main" data-content="about.intro">
-              I craft <span class="highlight">digital experiences</span> with a focus on
-              <span class="highlight">motion</span>, <span class="highlight">interaction</span>,
-              and <span class="highlight">visual storytelling</span>.
+              I build <span class="highlight">MEANINGFUL</span> products and help small teams
+              do their <span class="highlight">BEST WORK</span>.
             </p>
-            <p class="code-comment">/* Skills loaded */</p>
+            <p class="code-comment">/* How I work */</p>
             <p class="about-detail" data-content="about.detail">
-              With expertise spanning front-end development, UI/UX design, and creative coding,
-              I transform complex ideas into elegant, functional solutions.
+              I care about craft and iteration. I'd rather enable others than micromanage them.
+              Working with AI has made me even more optimistic about what focused teams can create.
             </p>
           </div>
 
@@ -419,7 +418,7 @@
 
           <!-- CRO: Urgency Banner -->
           <div class="contact-urgency">
-            <span>Currently accepting new clients for Q1 2025</span>
+            <span>Currently accepting new clients for Q2 2025</span>
           </div>
 
           <div class="contact-prompt">

--- a/frontend/themes/terminal/terminal.js
+++ b/frontend/themes/terminal/terminal.js
@@ -30,7 +30,7 @@ window.help = function() {
 ║  matrix()    - Enter the Matrix       ║
 ║  party()     - 🎉 Party mode!         ║
 ║  hack()      - Hack the mainframe     ║
-║  coffee()    - ☕ Refill coffee       ║
+║  ship()      - 🚀 Ship it now!        ║
 ║  enderman()  - 👾 Summon an Enderman  ║
 ║  reset()     - Reset to default       ║
 ╚═══════════════════════════════════════╝
@@ -64,9 +64,9 @@ window.hack = function() {
     console.log('%c[SUCCESS] Access granted! Just kidding 😄', 'color: #33ff00;');
 };
 
-window.coffee = function() {
-    console.log('%c☕ Coffee level restored to 100%!', 'color: #ffb000; font-size: 16px;');
-    console.log('%c[OK] Developer productivity increased by 200%', 'color: #33ff00;');
+window.ship = function() {
+    console.log('%c🚀 Another iteration deployed!', 'color: #ffb000; font-size: 16px;');
+    console.log('%c[OK] Small steps, meaningful progress.', 'color: #33ff00;');
 };
 
 window.enderman = function() {
@@ -283,7 +283,7 @@ function initLoadingSpinner() {
 // ─── Fun Random Terminal Messages ───
 function initRandomMessages() {
     const messages = [
-        '[INFO] Coffee break recommended in 30 minutes',
+        '[INFO] Good things take time and iteration',
         '[INFO] Remember to stretch! 🧘',
         '[OK] All systems nominal',
         '[INFO] Fun fact: This site runs on creativity',
@@ -391,10 +391,10 @@ async function initTerminalTheme() {
         'echo "Hello, World!"',
         'npm run create-awesome-stuff',
         'git commit -m "made it better"',
-        'sudo make me a sandwich',
-        'while(true) { code(); coffee(); }',
+        'sudo let me surf more',
+        'iterate() until meaningful(product)',
         './build-dreams.sh --with-passion',
-        'grep -r "bugs" . | rm -rf',
+        'grep -r "bugs" . | ./fix-them-with-ai-pipelines.sh',
     ];
 
     setTimeout(() => {


### PR DESCRIPTION
Update site identity to reflect a more grounded product engineer persona:

- Replace "Creative Developer" with "Product Engineer" throughout
- Change subtitle from "Building Digital Experiences" to "Building Things That Matter"
- Update about section to focus on meaningful work, craft, iteration, and enabling teams
- Replace coffee-themed easter eggs with iteration-focused alternatives
- Tone down "ship fast" messaging to more authentic voice
- Update terminal messages and typewriter text accordingly