### PR TITLE
Fix retro theme CTA colors and scroll spacing

### DIFF
--- a/frontend/css/cro.css
+++ b/frontend/css/cro.css
@@ -169,6 +169,12 @@ body[data-theme="retro90s"] .hero-cta:hover {
   border-style: inset;
   transform: translate(2px, 2px);
   box-shadow: 2px 2px 0 #000;
+  background: linear-gradient(180deg, #ffcc00 0%, #ff6600 100%);
+  color: #000;
+}
+
+body[data-theme="retro90s"] .hero-cta::before {
+  display: none;
 }
 
 /* ─── Social Proof Stats ─── */

--- a/frontend/themes/retro90s/retro90s.css
+++ b/frontend/themes/retro90s/retro90s.css
@@ -540,14 +540,15 @@ body[data-theme="retro90s"] .under-construction-inner::after {
 
 /* Scroll Indicator */
 body[data-theme="retro90s"] .scroll-indicator {
-  position: absolute;
-  bottom: var(--spacing-lg);
-  left: 50%;
-  transform: translateX(-50%);
+  position: relative;
+  bottom: auto;
+  left: auto;
+  transform: none;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  margin-top: var(--spacing-lg);
 }
 
 body[data-theme="retro90s"] .scroll-text {


### PR DESCRIPTION
- Fix hero CTA hover being unreadable (all black) by setting proper background/color on hover and hiding the ::before pseudo-element
- Fix scroll indicator overlapping with social proof stats by changing from absolute to relative positioning with proper margin