### PR TITLE
feat: repositioning Product Builder × Transformation IA

### DIFF
--- a/.claude/work/2026-04-25-093000-repositioning-builder-transformer.md
+++ b/.claude/work/2026-04-25-093000-repositioning-builder-transformer.md
@@ -1,0 +1,63 @@
+# Repositioning : Product Builder / Transformation IA
+
+**Status**: in_progress
+**Branch**: `feature/repositioning-builder-transformer`
+**Started**: 2026-04-25 09:30
+
+## Task
+
+Repositionner éditorialement tomandrieu.com pour refléter le double positionnement de Tom :
+- Product Builder (Lead Front-End @ CBA AgatheYOU + side projects)
+- Transformation IA (Platform Architect @ CBA, mission 6 mois + Studio Manifeste)
+
+À ne pas toucher : 4 thèmes + switcher, timeline git flow, ton perso.
+
+## Décisions éditoriales validées
+
+- **Hero titre** : `SALUT` (court, blog/perso)
+- **Hero citation** : Piste P4
+  > Je suis product builder.
+  > Mais à force de construire avec l'IA,
+  > j'ai commencé à transformer les équipes
+  > qui construisent des produits.
+  >
+  > Maintenant je fais les deux.
+- **Header brand** : `TOM ANDRIEU` (inchangé)
+- **Nav** : Now · Work · Writing · History · About · Contact
+- **Work** : 2 territoires empilés verticalement
+  - Product Builder (AgatheYOU, side projects, freelance)
+  - Transformation IA (Platform Architect @ CBA · mois 1/6, Studio Manifeste avec CTA externe)
+- **/now** : section home, format "avril 2026", source `data/{fr,en}/now.json`
+- **Mission CBA exacte** : Platform Architect (Plateforme & IA Agentique), date d'effet 2 avril 2026, durée 6 mois → mois 1/6 au 25 avril 2026
+
+## Files Being Modified
+
+- `frontend/index.html` (hero, nav, sections)
+- `frontend/data/{fr,en}/content.json` (textes principaux)
+- `frontend/data/{fr,en}/projects.json` (catégorisation Product Builder / Transformation IA)
+- `frontend/data/{fr,en}/git-history.json` (ajout branches Platform Architect + Studio Manifeste)
+- `frontend/data/{fr,en}/now.json` (NOUVEAU)
+- `frontend/i18n/locales/{fr,en}.json` (nav, sections, ui)
+- `frontend/i18n/themes/*/{fr,en}.json` (textes par thème)
+- `frontend/themes/*/*.js` (rendu hero typewriter, etc.)
+- `frontend/css/base.css` (styles hero + section /now)
+- `frontend/js/core/content-loader.js` (chargement now.json)
+
+## Progress
+
+- [x] Branche créée
+- [ ] Hero refactor
+- [ ] Nav restructurée
+- [ ] Section /now
+- [ ] Work refactor (2 territoires)
+- [ ] Writing intégré
+- [ ] Contact actualisé
+- [ ] Timeline enrichie
+- [ ] Test 4 thèmes
+- [ ] PR
+
+## Notes/Discoveries
+
+- Le PDF de mission n'est pas extractible automatiquement (pdftoppm absent), Tom a copié-collé le contenu dans le chat.
+- L'ancienne section blog est commentée dans index.html mais blog.html existe en page séparée — réactivation prévue côté home.
+- La nav passe de 4 items à 6, surveiller le rendu mobile.

--- a/frontend/blog.html
+++ b/frontend/blog.html
@@ -118,19 +118,27 @@
     </div>
     <div class="header-right">
       <nav class="nav" id="main-nav" role="navigation" aria-label="Main navigation">
-        <a href="/#projects" class="nav-link" data-section="01">
+        <a href="/#now" class="nav-link" data-section="01">
           <span class="nav-prefix"></span>
-          <span class="nav-text" data-i18n="nav.projects">Projects</span>
+          <span class="nav-text" data-i18n="nav.now">Now</span>
         </a>
-        <a href="/#about" class="nav-link" data-section="02">
+        <a href="/#work" class="nav-link" data-section="02">
           <span class="nav-prefix"></span>
-          <span class="nav-text" data-i18n="nav.about">About</span>
+          <span class="nav-text" data-i18n="nav.work">Work</span>
         </a>
-        <a href="/#timeline" class="nav-link" data-section="03">
+        <a href="/#writing" class="nav-link" data-section="03">
+          <span class="nav-prefix"></span>
+          <span class="nav-text" data-i18n="nav.writing">Writing</span>
+        </a>
+        <a href="/#timeline" class="nav-link" data-section="04">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.history">History</span>
         </a>
-        <a href="/#contact" class="nav-link" data-section="05">
+        <a href="/#about" class="nav-link" data-section="05">
+          <span class="nav-prefix"></span>
+          <span class="nav-text" data-i18n="nav.about">About</span>
+        </a>
+        <a href="/#contact" class="nav-link" data-section="06">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.contact">Contact</span>
         </a>

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -764,6 +764,90 @@ body.loading * {
   animation: pulse 1.5s infinite;
 }
 
+/* ─── /Now Section (current status) ─── */
+.now-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.now-date {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.875em;
+  letter-spacing: 0.02em;
+}
+
+.now-intro {
+  margin-bottom: 1.25rem;
+}
+
+.now-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.now-list-loading {
+  opacity: 0.5;
+  font-style: italic;
+}
+
+.now-item {
+  display: grid;
+  grid-template-columns: 1.5rem 7rem 1fr;
+  gap: 0.75rem;
+  align-items: baseline;
+  line-height: 1.55;
+}
+
+@media (max-width: 640px) {
+  .now-item {
+    grid-template-columns: 1.5rem 1fr;
+  }
+  .now-item .now-label {
+    grid-column: 2;
+  }
+  .now-item .now-value {
+    grid-column: 1 / -1;
+    padding-left: 2.25rem;
+  }
+}
+
+.now-arrow {
+  opacity: 0.6;
+}
+
+.now-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.85em;
+  opacity: 0.75;
+}
+
+.now-value {
+  opacity: 0.95;
+}
+
+.now-link {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.now-link-arrow {
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
 /* ─── Hero Quote (multi-line manifesto) ─── */
 .hero-quote {
   display: flex;

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -764,3 +764,26 @@ body.loading * {
   animation: pulse 1.5s infinite;
 }
 
+/* ─── Hero Quote (multi-line manifesto) ─── */
+.hero-quote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  text-align: center;
+  position: relative;
+}
+
+.hero-quote-line {
+  margin: 0;
+  line-height: 1.6;
+  font-size: inherit;
+  color: inherit;
+}
+
+.hero-quote-final {
+  margin-top: 0.6rem;
+  font-weight: 600;
+  font-style: italic;
+}
+

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -764,6 +764,14 @@ body.loading * {
   animation: pulse 1.5s infinite;
 }
 
+/* ─── Writing Section ─── */
+.writing-intro {
+  margin-bottom: 1.75rem;
+  opacity: 0.75;
+  font-size: 0.95rem;
+  max-width: 38rem;
+}
+
 /* ─── Work Territories (Product Builder / Transformation IA) ─── */
 .work-territory {
   margin-bottom: 3rem;

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -764,6 +764,49 @@ body.loading * {
   animation: pulse 1.5s infinite;
 }
 
+/* ─── Work Territories (Product Builder / Transformation IA) ─── */
+.work-territory {
+  margin-bottom: 3rem;
+}
+
+.work-territory:last-child {
+  margin-bottom: 0;
+}
+
+.work-territory-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px dashed currentColor;
+  opacity: 0.95;
+}
+
+.work-territory-header > * {
+  opacity: 1;
+}
+
+.work-territory-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 0.25rem;
+}
+
+.work-territory-subtitle {
+  font-size: 0.875rem;
+  margin: 0;
+  opacity: 0.7;
+}
+
+.projects-grid-hidden {
+  display: none !important;
+}
+
+/* Cards without URL (e.g. internal mission descriptions) */
+.project-card.no-url {
+  cursor: default;
+}
+
 /* ─── /Now Section (current status) ─── */
 .now-card-header {
   display: flex;

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -816,12 +816,23 @@ body.loading * {
 }
 
 /* ─── /Now Section (current status) ─── */
+/* Force the /now card-header to render even in themes that hide .card-header globally */
+#now .card-header,
 .now-card-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
+}
+
+/* Code comment markers around the intro — hidden by default, shown only in terminal */
+.code-comment-marker {
+  display: none;
+}
+body[data-theme="terminal"] .code-comment-marker {
+  display: inline;
+  opacity: 0.55;
 }
 
 .now-date {

--- a/frontend/data/en/content.json
+++ b/frontend/data/en/content.json
@@ -1,21 +1,27 @@
 {
   "meta": {
     "name": "Tom Andrieu",
-    "title": "Product Engineer",
-    "description": "Product Engineer. I build products end-to-end, talk to users, iterate fast, and help teams do their best work."
+    "title": "Product Builder · AI Transformation",
+    "description": "Product Builder and AI Transformation. I build products, and I transform with AI the teams that build products."
   },
   "hero": {
-    "title": ["PRODUCT", "ENGINEER"],
-    "subtitle": "BUILD. REFINE. OWN THE OUTCOME."
+    "title": "HEY",
+    "quote": [
+      "I'm a product builder.",
+      "But by building with AI,",
+      "I started transforming the teams",
+      "who build products.",
+      "Now I do both."
+    ]
   },
   "about": {
-    "intro": "I build products for <highlight>REAL USERS</highlight> and help small teams <highlight>MOVE FAST</highlight>.",
-    "detail": "I talk to users, own problems end-to-end, and iterate until it works. I'd rather build something small that matters than plan something big that doesn't. Working with AI has made me even more optimistic about what focused teams can create.",
+    "intro": "I build <highlight>PRODUCTS</highlight>, and I transform with <highlight>AI</highlight> the teams who build them.",
+    "detail": "Build side: Lead Front-End @ CBA (AgatheYOU) and side projects. Transform side: Platform Architect @ CBA (6-month mission on the platform & agentic AI) and co-founder of Studio Manifeste, the AI agency for SMEs. Same craft, two sides.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ YEARS",
-      "focus": "PRODUCT ENGINEERING",
-      "status": "AVAILABLE FOR PROJECTS"
+      "focus": "PRODUCT BUILDER · AGENTIC AI",
+      "status": "ON MISSION"
     }
   },
   "techStack": [

--- a/frontend/data/en/git-history.json
+++ b/frontend/data/en/git-history.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "title": "JOURNEY",
-    "subtitle": "From student to product engineer",
+    "subtitle": "From student to lead",
     "startYear": 2017,
     "endYear": 2027
   },
@@ -151,11 +151,46 @@
           "message": "Joined CBA as Lead Developer",
           "author": "CBA Informatique Liberale",
           "details": {
-            "title": "Lead Developer",
+            "title": "Lead Developer · Lead Front-End AgatheYOU",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Leading a team of 8 developers building web and mobile applications with Angular & Ionic. Architecting multiple applications and implementing CI/CD pipeline.",
             "tags": ["Angular", "Ionic", "CI/CD", "Team Lead"]
+          }
+        },
+        {
+          "hash": "cba2026pa",
+          "date": "2026-04",
+          "message": "Platform Architect mission — Platform & Agentic AI (6 months)",
+          "author": "CBA Informatique Liberale",
+          "details": {
+            "title": "Platform Architect (Platform & Agentic AI)",
+            "company": "CBA Informatique Liberale",
+            "location": "Avignon, France",
+            "description": "6-month mission (Apr. 2026 → Sept. 2026) alongside the Lead Front-End role. Design and evolve a development and design platform, integrate agentic capabilities, support product and tech teams, spread a platform culture.",
+            "tags": ["Agentic AI", "Platform Engineering", "Developer Experience", "Product Experience"]
+          }
+        }
+      ]
+    },
+    {
+      "id": "studio-manifeste",
+      "name": "Studio Manifeste",
+      "type": "project",
+      "startDate": "2026-01",
+      "endDate": "ongoing",
+      "commits": [
+        {
+          "hash": "stm2026",
+          "date": "2026-01",
+          "message": "Co-founded Studio Manifeste",
+          "author": "Studio Manifeste",
+          "details": {
+            "title": "Co-founder",
+            "company": "Studio Manifeste",
+            "location": "studio.alphaluppi.fr",
+            "description": "AI agency for SMEs. We help SMEs integrate AI into their business — advisory, integration, training. No hype, no bullshit.",
+            "tags": ["AI Agency", "SMEs", "Co-founder", "Advisory"]
           }
         }
       ]

--- a/frontend/data/en/now.json
+++ b/frontend/data/en/now.json
@@ -1,0 +1,31 @@
+{
+  "date": "April 2026",
+  "headerLabel": "WHERE I'M AT",
+  "intro": "Living section. Updated when things move.",
+  "items": [
+    {
+      "key": "build",
+      "label": "Build",
+      "value": "Lead Front-End @ CBA · AgatheYOU · side projects."
+    },
+    {
+      "key": "transform",
+      "label": "Transform",
+      "value": "Platform Architect @ CBA · month 1/6 — platform & agentic AI for product and tech teams."
+    },
+    {
+      "key": "studio",
+      "label": "Studio",
+      "value": "Studio Manifeste — the AI agency for SMEs, in the works.",
+      "link": {
+        "url": "https://studio.alphaluppi.fr",
+        "text": "studio.alphaluppi.fr"
+      }
+    },
+    {
+      "key": "freelance",
+      "label": "Freelance",
+      "value": "No open mission right now."
+    }
+  ]
+}

--- a/frontend/data/en/projects.json
+++ b/frontend/data/en/projects.json
@@ -1,9 +1,18 @@
 [
     {
+        "id": "agatheyou",
+        "title": "AgatheYOU",
+        "description": "Lead Front-End on AgatheYOU @ CBA. Health app for liberal practitioners, Angular & Ionic, team of 8 developers.",
+        "type": "PRODUCT (CBA)",
+        "category": "product-builder",
+        "tags": ["Angular", "Ionic", "Lead Front-End", "Healthcare"]
+    },
+    {
         "id": "ride-my-park",
         "title": "Ride My Park",
         "description": "Find nearby spots among 30K skateparks, street spots & pumptracks for BMX, Skateboard, Aggressive Inline, Freestyle Scooter on Ride My Park.",
         "type": "WEB APPLICATION",
+        "category": "product-builder",
         "url": "https://ridemypark.com",
         "images": [
             "/assets/ridemypark-mobile-store-wallpaper.jpg",
@@ -17,6 +26,7 @@
         "title": "Skoolbook",
         "description": "Skoolbook is a platform I designed with my partner, a school teacher, to optimize school library management. It offers an intuitive interface for teachers, simplifies book loan tracking, and encourages student autonomy.",
         "type": "WEB APPLICATION",
+        "category": "product-builder",
         "url": "https://skoolbook.fr",
         "images": [
             "/assets/skoolbook-landing-page.png",
@@ -31,6 +41,7 @@
         "title": "Teach Tools",
         "description": "A digital teaching assistant with innovative tools to simplify teachers' daily work. Generate exercises and images using AI.",
         "type": "AI TOOL",
+        "category": "product-builder",
         "url": "https://teach-tools.com",
         "images": [
             "/assets/teach-tools-exercise-generation.png",
@@ -45,6 +56,7 @@
         "title": "GyroDex",
         "description": "A pokedex for Animal Crossing. List and save which Animal Crossing creatures you've collected, with friends. Full vibe coding to have fun with AI.",
         "type": "WEB APP",
+        "category": "product-builder",
         "url": "https://v0-animal-crossing-gyroides.vercel.app",
         "images": [
             "/assets/girodex-gyroide-collection.png",
@@ -52,5 +64,22 @@
             "/assets/girodex-friends-dashboard.png"
         ],
         "tags": ["Next.js", "Vercel", "Gaming"]
+    },
+    {
+        "id": "platform-architect-cba",
+        "title": "Platform Architect @ CBA",
+        "description": "6-month mission: design and evolve a development and design platform integrating agentic capabilities, to improve efficiency, quality and autonomy of product and technical teams. Platform, tools, agents, enablement, evangelism.",
+        "type": "MISSION (6 MONTHS)",
+        "category": "transformation-ia",
+        "tags": ["Agentic AI", "Platform Engineering", "Developer Experience", "Product Experience"]
+    },
+    {
+        "id": "studio-manifeste",
+        "title": "Studio Manifeste",
+        "description": "AI agency for SMEs that I'm co-founding. We help SMEs integrate AI into their business, without hype and without bullshit. Advisory, integration, training.",
+        "type": "AI AGENCY",
+        "category": "transformation-ia",
+        "url": "https://studio.alphaluppi.fr",
+        "tags": ["AI Agency", "SMEs", "Co-founder", "Advisory"]
     }
 ]

--- a/frontend/data/fr/content.json
+++ b/frontend/data/fr/content.json
@@ -1,21 +1,27 @@
 {
   "meta": {
     "name": "Tom Andrieu",
-    "title": "Product Engineer",
-    "description": "Product Engineer. Je construis des produits de A à Z, je parle aux users, j'itère vite, et j'aide les équipes à faire du bon boulot."
+    "title": "Product Builder · Transformation IA",
+    "description": "Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits."
   },
   "hero": {
-    "title": ["PRODUCT", "ENGINEER"],
-    "subtitle": "BUILD. REFINE. OWN THE OUTCOME."
+    "title": "SALUT",
+    "quote": [
+      "Je suis product builder.",
+      "Mais à force de construire avec l'IA,",
+      "j'ai commencé à transformer les équipes",
+      "qui construisent des produits.",
+      "Maintenant je fais les deux."
+    ]
   },
   "about": {
-    "intro": "Je construis des produits pour de <highlight>VRAIS USERS</highlight> et j'aide les petites équipes à <highlight>AVANCER VITE</highlight>.",
-    "detail": "Je parle aux utilisateurs, je gère les problèmes de bout en bout, et j'itère jusqu'à ce que ça marche. Je préfère construire un truc petit qui compte plutôt que planifier un machin énorme qui marchera jamais. Bosser avec l'IA m'a rendu optimiste sur ce que des équipes focus peuvent créer.",
+    "intro": "Je construis des <highlight>PRODUITS</highlight>, et je transforme par l'<highlight>IA</highlight> les équipes qui en construisent.",
+    "detail": "Côté build : Lead Front-End @ CBA (AgatheYOU) et side projects. Côté transformation : Platform Architect @ CBA (mission 6 mois sur la plateforme & IA agentique) et co-fondateur du Studio Manifeste, l'agence IA pour PME. C'est le même métier, vu de deux côtés.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ ANS",
-      "focus": "PRODUCT ENGINEERING",
-      "status": "DISPO POUR PROJETS"
+      "focus": "PRODUCT BUILDER · IA AGENTIQUE",
+      "status": "MISSION EN COURS"
     }
   },
   "techStack": [

--- a/frontend/data/fr/git-history.json
+++ b/frontend/data/fr/git-history.json
@@ -151,11 +151,46 @@
           "message": "Arrivée chez CBA en tant que Lead Dev",
           "author": "CBA Informatique Liberale",
           "details": {
-            "title": "Lead Developer",
+            "title": "Lead Developer · Lead Front-End AgatheYOU",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Lead d'une équipe de 8 développeurs construisant applications web et mobiles avec Angular & Ionic. Architecture multi-applications et mise en place pipeline CI/CD.",
             "tags": ["Angular", "Ionic", "CI/CD", "Team Lead"]
+          }
+        },
+        {
+          "hash": "cba2026pa",
+          "date": "2026-04",
+          "message": "Mission Platform Architect — Plateforme & IA Agentique (6 mois)",
+          "author": "CBA Informatique Liberale",
+          "details": {
+            "title": "Platform Architect (Plateforme & IA Agentique)",
+            "company": "CBA Informatique Liberale",
+            "location": "Avignon, France",
+            "description": "Mission de 6 mois (avr. 2026 → sept. 2026) en parallèle du Lead Front-End. Concevoir et faire évoluer une plateforme de développement et de conception, intégrer des capacités agentiques, accompagner les équipes produit et techniques, diffuser une culture plateforme.",
+            "tags": ["IA Agentique", "Platform Engineering", "Developer Experience", "Product Experience"]
+          }
+        }
+      ]
+    },
+    {
+      "id": "studio-manifeste",
+      "name": "Studio Manifeste",
+      "type": "project",
+      "startDate": "2026-01",
+      "endDate": "ongoing",
+      "commits": [
+        {
+          "hash": "stm2026",
+          "date": "2026-01",
+          "message": "Co-fondation Studio Manifeste",
+          "author": "Studio Manifeste",
+          "details": {
+            "title": "Co-fondateur",
+            "company": "Studio Manifeste",
+            "location": "studio.alphaluppi.fr",
+            "description": "Agence IA pour PME. On aide les PME à intégrer l'IA dans leur métier — conseil, intégration, formation. Sans hype et sans bullshit.",
+            "tags": ["Agence IA", "PME", "Co-fondateur", "Conseil"]
           }
         }
       ]

--- a/frontend/data/fr/now.json
+++ b/frontend/data/fr/now.json
@@ -1,0 +1,31 @@
+{
+  "date": "avril 2026",
+  "headerLabel": "OÙ J'EN SUIS",
+  "intro": "Section vivante. Mise à jour quand ça bouge.",
+  "items": [
+    {
+      "key": "build",
+      "label": "Build",
+      "value": "Lead Front-End @ CBA · AgatheYOU · side projects."
+    },
+    {
+      "key": "transform",
+      "label": "Transform",
+      "value": "Platform Architect @ CBA · mois 1/6 — plateforme & IA agentique pour les équipes produit et tech."
+    },
+    {
+      "key": "studio",
+      "label": "Studio",
+      "value": "Studio Manifeste — l'agence IA pour PME, en construction.",
+      "link": {
+        "url": "https://studio.alphaluppi.fr",
+        "text": "studio.alphaluppi.fr"
+      }
+    },
+    {
+      "key": "freelance",
+      "label": "Freelance",
+      "value": "Pas de mission ouverte pour le moment."
+    }
+  ]
+}

--- a/frontend/data/fr/projects.json
+++ b/frontend/data/fr/projects.json
@@ -1,9 +1,18 @@
 [
     {
+        "id": "agatheyou",
+        "title": "AgatheYOU",
+        "description": "Lead Front-End sur AgatheYOU @ CBA. Application santé pour les professionnels libéraux, Angular & Ionic, équipe de 8 développeurs.",
+        "type": "PRODUIT (CBA)",
+        "category": "product-builder",
+        "tags": ["Angular", "Ionic", "Lead Front-End", "Santé"]
+    },
+    {
         "id": "ride-my-park",
         "title": "Ride My Park",
         "description": "Trouvez des spots près de chez vous parmi 30K skateparks, street spots et pumptracks pour BMX, Skateboard, Roller, Trottinette Freestyle sur Ride My Park.",
         "type": "APPLICATION WEB",
+        "category": "product-builder",
         "url": "https://ridemypark.com",
         "images": [
             "/assets/ridemypark-mobile-store-wallpaper.jpg",
@@ -17,6 +26,7 @@
         "title": "Skoolbook",
         "description": "Skoolbook, c'est une appli que j'ai construite avec ma conjointe instit. L'idée : simplifier la gestion des bibliothèques de classe. Les profs peuvent suivre les emprunts facilement, et les élèves gèrent leurs livres en autonomie.",
         "type": "APPLICATION WEB",
+        "category": "product-builder",
         "url": "https://skoolbook.fr",
         "images": [
             "/assets/skoolbook-landing-page.png",
@@ -31,6 +41,7 @@
         "title": "Teach Tools",
         "description": "Des outils pour les profs. Génère des exercices et des images grâce à l'IA. Simple et pratique pour le quotidien.",
         "type": "OUTIL IA",
+        "category": "product-builder",
         "url": "https://teach-tools.com",
         "images": [
             "/assets/teach-tools-exercise-generation.png",
@@ -45,6 +56,7 @@
         "title": "GyroDex",
         "description": "Un pokédex pour Animal Crossing. Liste et permet de sauvegarder quelles créatures d'Animal Crossing vous avez collectées, avec des amis. Full vibe coding pour m'amuser avec l'IA.",
         "type": "APP WEB",
+        "category": "product-builder",
         "url": "https://v0-animal-crossing-gyroides.vercel.app",
         "images": [
             "/assets/girodex-gyroide-collection.png",
@@ -52,5 +64,22 @@
             "/assets/girodex-friends-dashboard.png"
         ],
         "tags": ["Next.js", "Vercel", "Gaming"]
+    },
+    {
+        "id": "platform-architect-cba",
+        "title": "Platform Architect @ CBA",
+        "description": "Mission de 6 mois : concevoir et faire évoluer une plateforme de développement et de conception, intégrant des capacités agentiques, pour améliorer l'efficacité, la qualité et l'autonomie des équipes produit et techniques. Plateforme, outils, agents, accompagnement, vulgarisation.",
+        "type": "MISSION (6 MOIS)",
+        "category": "transformation-ia",
+        "tags": ["IA Agentique", "Platform Engineering", "Developer Experience", "Product Experience"]
+    },
+    {
+        "id": "studio-manifeste",
+        "title": "Studio Manifeste",
+        "description": "Agence IA pour PME que je co-fonde. On aide les PME à intégrer l'IA dans leur métier, sans hype et sans bullshit. Conseil, intégration, formation.",
+        "type": "AGENCE IA",
+        "category": "transformation-ia",
+        "url": "https://studio.alphaluppi.fr",
+        "tags": ["Agence IA", "PME", "Co-fondateur", "Conseil"]
     }
 ]

--- a/frontend/i18n/language-manager.js
+++ b/frontend/i18n/language-manager.js
@@ -64,8 +64,9 @@ const LanguageManager = (() => {
 
     function populateTranslations() {
         document.querySelectorAll('[data-i18n]').forEach(el => {
-            const value = t(el.dataset.i18n);
-            if (value && typeof value === 'string') {
+            const key = el.dataset.i18n;
+            const value = t(key);
+            if (value && typeof value === 'string' && value !== key) {
                 el.innerHTML = value
                     .replace(/<highlight>/g, '<span class="highlight">')
                     .replace(/<\/highlight>/g, '</span>');

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -1,21 +1,27 @@
 {
   "meta": {
     "name": "Tom Andrieu",
-    "title": "Product Engineer",
-    "description": "Product engineer who builds meaningful products, iterates with purpose, and helps teams do their best work."
+    "title": "Product Builder · AI Transformation",
+    "description": "Product Builder and AI Transformation. I build products, and I transform with AI the teams that build products."
   },
   "hero": {
-    "title": ["PRODUCT", "ENGINEER"],
-    "subtitle": "BUILDING THINGS THAT MATTER"
+    "title": "HEY",
+    "quote": [
+      "I'm a product builder.",
+      "But by building with AI,",
+      "I started transforming the teams",
+      "who build products.",
+      "Now I do both."
+    ]
   },
   "about": {
-    "intro": "I build <highlight>MEANINGFUL</highlight> products and help small teams do their <highlight>BEST WORK</highlight>.",
-    "detail": "I care about craft and iteration. I'd rather enable others than micromanage them. Working with AI has made me even more optimistic about what focused teams can create.",
+    "intro": "I build <highlight>PRODUCTS</highlight>, and I transform with <highlight>AI</highlight> the teams who build them.",
+    "detail": "Build side: Lead Front-End @ CBA (AgatheYOU) and side projects. Transform side: Platform Architect @ CBA (6-month mission on the platform & agentic AI) and co-founder of Studio Manifeste, the AI agency for SMEs. Same craft, two sides.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ YEARS",
-      "focus": "PRODUCT ENGINEERING",
-      "status": "AVAILABLE FOR PROJECTS"
+      "focus": "PRODUCT BUILDER · AGENTIC AI",
+      "status": "ON MISSION"
     },
     "specLabels": {
       "location": "LOCATION",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -102,6 +102,16 @@
     "headerLabel": "WHERE I'M AT",
     "intro": "Living section. Updated when things move."
   },
+  "work": {
+    "productBuilder": {
+      "title": "PRODUCT BUILDER",
+      "subtitle": "Lead Front-End @ CBA · AgatheYOU · side projects."
+    },
+    "transformationIa": {
+      "title": "AI TRANSFORMATION",
+      "subtitle": "Platform & agentic AI at CBA, AI agency at Studio Manifeste."
+    }
+  },
   "blog": {
     "subtitle": "Thoughts on product engineering, building meaningful products, and technology.",
     "minRead": "min read",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -78,6 +78,7 @@
     "waitLetsConnect": "Wait! Let's Connect",
     "haveProjectInMind": "Have a project in mind? I'd love to hear about it.",
     "availableForProjects": "Available for Projects",
+    "openToConversations": "Open to conversations",
     "acceptingClients": "Currently accepting new clients for Q2 2025",
     "typicallyResponds": "Typically responds within 24 hours",
     "establishConnection": "ESTABLISH CONNECTION",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -66,6 +66,7 @@
   },
   "ui": {
     "loading": "Loading...",
+    "loadingNow": "Loading...",
     "loadingProjects": "Loading projects...",
     "noArticles": "No articles yet. Check back soon!",
     "viewAllArticles": "VIEW ALL ARTICLES",
@@ -96,6 +97,10 @@
     "yearsExperience": "Years Experience",
     "usersReached": "Users Reached",
     "liveProducts": "Live Products"
+  },
+  "now": {
+    "headerLabel": "WHERE I'M AT",
+    "intro": "Living section. Updated when things move."
   },
   "blog": {
     "subtitle": "Thoughts on product engineering, building meaningful products, and technology.",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -45,6 +45,9 @@
     "email": "CONTACT@TOMANDRIEU.COM"
   },
   "nav": {
+    "now": "Now",
+    "work": "Work",
+    "writing": "Writing",
     "projects": "Projects",
     "about": "About",
     "blog": "Blog",
@@ -52,6 +55,9 @@
     "history": "History"
   },
   "sections": {
+    "now": "/NOW",
+    "work": "WORK",
+    "writing": "WRITING",
     "projects": "PROJECTS",
     "about": "ABOUT",
     "blog": "BLOG",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -112,6 +112,9 @@
       "subtitle": "Platform & agentic AI at CBA, AI agency at Studio Manifeste."
     }
   },
+  "writing": {
+    "intro": "Notes, posts, and what I'm learning while building."
+  },
   "blog": {
     "subtitle": "Thoughts on product engineering, building meaningful products, and technology.",
     "minRead": "min read",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -1,21 +1,27 @@
 {
   "meta": {
     "name": "Tom Andrieu",
-    "title": "Product Engineer",
-    "description": "Développeur Fullstack & Product. Je conçois et développe des produits de A à Z."
+    "title": "Product Builder · Transformation IA",
+    "description": "Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits."
   },
   "hero": {
-    "title": ["PRODUCT", "ENGINEER"],
-    "subtitle": "DÉVELOPPEUR FULLSTACK & PRODUCT"
+    "title": "SALUT",
+    "quote": [
+      "Je suis product builder.",
+      "Mais à force de construire avec l'IA,",
+      "j'ai commencé à transformer les équipes",
+      "qui construisent des produits.",
+      "Maintenant je fais les deux."
+    ]
   },
   "about": {
-    "intro": "Je conçois et développe des <highlight>PRODUITS</highlight> de A à Z, du premier coup de crayon jusqu'au déploiement.",
-    "detail": "J'aime les projets où on peut avancer vite, tester des idées, et voir le résultat. Que ce soit pour une startup, un side project, ou une équipe qui a besoin de renfort — côté code ou côté organisation.",
+    "intro": "Je construis des <highlight>PRODUITS</highlight>, et je transforme par l'<highlight>IA</highlight> les équipes qui en construisent.",
+    "detail": "Côté build : Lead Front-End @ CBA (AgatheYOU) et side projects. Côté transformation : Platform Architect @ CBA (mission 6 mois sur la plateforme & IA agentique) et co-fondateur du Studio Manifeste, l'agence IA pour PME. C'est le même métier, vu de deux côtés.",
     "specs": {
       "location": "FRANCE",
-      "experience": "7+ ANS",
-      "focus": "PRODUCT ENGINEERING",
-      "status": "DISPO POUR PROJETS"
+      "experience": "8+ ANS",
+      "focus": "PRODUCT BUILDER · IA AGENTIQUE",
+      "status": "MISSION EN COURS"
     },
     "specLabels": {
       "location": "LOCALISATION",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -45,6 +45,9 @@
     "email": "CONTACT@TOMANDRIEU.COM"
   },
   "nav": {
+    "now": "Now",
+    "work": "Work",
+    "writing": "Écrits",
     "projects": "Projets",
     "about": "À propos",
     "blog": "Blog",
@@ -52,6 +55,9 @@
     "history": "Historique"
   },
   "sections": {
+    "now": "/NOW",
+    "work": "WORK",
+    "writing": "ÉCRITS",
     "projects": "PROJETS",
     "about": "À PROPOS",
     "blog": "BLOG",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -112,6 +112,9 @@
       "subtitle": "Plateforme & IA agentique chez CBA, agence IA chez Studio Manifeste."
     }
   },
+  "writing": {
+    "intro": "Notes, posts, et ce que j'apprends en construisant."
+  },
   "blog": {
     "subtitle": "Product engineering, création de produits, et technologie.",
     "minRead": "min de lecture",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -78,6 +78,7 @@
     "waitLetsConnect": "Hey, on se connecte ?",
     "haveProjectInMind": "Un projet en tête ? Parlons-en.",
     "availableForProjects": "Dispo pour des projets",
+    "openToConversations": "Ouvert aux échanges",
     "acceptingClients": "J'accepte de nouveaux clients pour Q2",
     "typicallyResponds": "Réponse sous 24h",
     "establishConnection": "CONNECTER",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -102,6 +102,16 @@
     "headerLabel": "OÙ J'EN SUIS",
     "intro": "Section vivante. Mise à jour quand ça bouge."
   },
+  "work": {
+    "productBuilder": {
+      "title": "PRODUCT BUILDER",
+      "subtitle": "Lead Front-End @ CBA · AgatheYOU · side projects."
+    },
+    "transformationIa": {
+      "title": "TRANSFORMATION IA",
+      "subtitle": "Plateforme & IA agentique chez CBA, agence IA chez Studio Manifeste."
+    }
+  },
   "blog": {
     "subtitle": "Product engineering, création de produits, et technologie.",
     "minRead": "min de lecture",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -66,6 +66,7 @@
   },
   "ui": {
     "loading": "Chargement...",
+    "loadingNow": "Chargement...",
     "loadingProjects": "Chargement des projets...",
     "noArticles": "Pas encore d'articles. Revenez bientôt !",
     "viewAllArticles": "VOIR TOUS LES ARTICLES",
@@ -96,6 +97,10 @@
     "yearsExperience": "Ans d'XP",
     "usersReached": "Utilisateurs",
     "liveProducts": "Produits en prod"
+  },
+  "now": {
+    "headerLabel": "OÙ J'EN SUIS",
+    "intro": "Section vivante. Mise à jour quand ça bouge."
   },
   "blog": {
     "subtitle": "Product engineering, création de produits, et technologie.",

--- a/frontend/i18n/themes/terminal/en.json
+++ b/frontend/i18n/themes/terminal/en.json
@@ -42,9 +42,10 @@
     "colorsReset": "[SYSTEM] Colors reset to default"
   },
   "terminalOutput": {
-    "loadingModules": "[OK] Loading modules...",
-    "productEngineerInit": "[OK] Product engineer initialized",
-    "readyToBuild": "[OK] Ready to build something meaningful"
+    "loadingModules": "Loading modules...",
+    "productBuilderInit": "Product builder initialized",
+    "aiTransformerOnline": "AI transformer online",
+    "readyToBuild": "Ready to ship"
   },
   "heroStats": {
     "creativity": "CREATIVITY",

--- a/frontend/i18n/themes/terminal/fr.json
+++ b/frontend/i18n/themes/terminal/fr.json
@@ -42,9 +42,10 @@
     "colorsReset": "[SYSTÈME] Couleurs réinitialisées"
   },
   "terminalOutput": {
-    "loadingModules": "[OK] Chargement des modules...",
-    "productEngineerInit": "[OK] Product engineer initialisé",
-    "readyToBuild": "[OK] Ready to ship"
+    "loadingModules": "Chargement des modules...",
+    "productBuilderInit": "Product builder initialisé",
+    "aiTransformerOnline": "Transformer IA en ligne",
+    "readyToBuild": "Prêt à ship"
   },
   "heroStats": {
     "creativity": "CRÉATIVITÉ",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -539,12 +539,7 @@
           <!-- CRO: Availability Badge -->
           <div class="availability-badge">
             <span class="availability-dot"></span>
-            <span data-i18n="ui.availableForProjects">Available for Projects</span>
-          </div>
-
-          <!-- CRO: Urgency Banner -->
-          <div class="contact-urgency">
-            <span data-i18n="ui.acceptingClients">Currently accepting new clients for Q2 2025</span>
+            <span data-i18n="ui.openToConversations">Open to conversations</span>
           </div>
 
           <div class="contact-prompt">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -340,6 +340,33 @@
     </div>
   </section>
 
+  <!-- /Now Section (current status, living) -->
+  <section id="now" class="now">
+    <div class="section-header">
+      <div class="section-label">
+        <span class="section-number">01</span>
+        <span class="section-prompt">$</span>
+        <h2 class="section-title" data-glitch="/NOW" data-i18n="sections.now">/NOW</h2>
+      </div>
+      <div class="section-divider">═══════════════════════════════════════════════════════</div>
+    </div>
+
+    <div class="now-content">
+      <div class="now-card about-card">
+        <div class="card-header now-card-header">
+          <span class="card-title" data-i18n="now.headerLabel">OÙ J'EN SUIS</span>
+          <span class="now-date" id="now-date" data-content="now.date">avril 2026</span>
+        </div>
+        <div class="card-body">
+          <p class="code-comment now-intro"><span data-i18n="now.intro">Section vivante. Mise à jour quand ça bouge.</span></p>
+          <ul class="now-list" id="now-list">
+            <li class="now-list-loading" data-i18n="ui.loadingNow">Chargement...</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Work Section (formerly Projects) -->
   <section id="work" class="projects work">
     <div class="section-header">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tom Andrieu - Product Engineer</title>
-  <meta name="description" content="Product engineer who builds meaningful products, iterates with purpose, and helps teams do their best work." />
+  <title>Tom Andrieu — Product Builder · Transformation IA</title>
+  <meta name="description" content="Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits. CBA · AgatheYOU · Studio Manifeste." />
 
   <!-- PostHog Analytics (centralized) -->
   <script src="/js/analytics.js"></script>
@@ -255,22 +255,25 @@
           <span class="cursor-blink">_</span>
         </div>
         <div class="terminal-output">
-          <p class="output-line">[<span class="status-ok">OK</span>] Loading modules...</p>
-          <p class="output-line">[<span class="status-ok">OK</span>] Product engineer initialized</p>
-          <p class="output-line">[<span class="status-ok">OK</span>] Ready to build something meaningful</p>
+          <p class="output-line">[<span class="status-ok">OK</span>] <span data-i18n="terminalOutput.loadingModules">Loading modules...</span></p>
+          <p class="output-line">[<span class="status-ok">OK</span>] <span data-i18n="terminalOutput.productBuilderInit">Product builder initialized</span></p>
+          <p class="output-line">[<span class="status-ok">OK</span>] <span data-i18n="terminalOutput.aiTransformerOnline">AI transformer online</span></p>
         </div>
       </div>
 
-      <h1 class="hero-title">
-        <span class="title-line" data-i18n="hero.title.0">PRODUCT</span>
-        <span class="title-line" data-i18n="hero.title.1">ENGINEER</span>
+      <h1 class="hero-title hero-title-greeting">
+        <span class="title-line" data-i18n="hero.title">SALUT</span>
       </h1>
 
-      <p class="hero-subtitle">
-        <span class="annotation-mark"></span>
-        <span data-i18n="hero.subtitle">BUILDING THINGS THAT MATTER</span>
-        <span class="annotation-mark"></span>
-      </p>
+      <div class="hero-subtitle hero-quote">
+        <span class="annotation-mark hero-quote-mark-open"></span>
+        <p class="hero-quote-line" data-i18n="hero.quote.0">Je suis product builder.</p>
+        <p class="hero-quote-line" data-i18n="hero.quote.1">Mais à force de construire avec l'IA,</p>
+        <p class="hero-quote-line" data-i18n="hero.quote.2">j'ai commencé à transformer les équipes</p>
+        <p class="hero-quote-line" data-i18n="hero.quote.3">qui construisent des produits.</p>
+        <p class="hero-quote-line hero-quote-final" data-i18n="hero.quote.4">Maintenant je fais les deux.</p>
+        <span class="annotation-mark hero-quote-mark-close"></span>
+      </div>
 
       <!-- 90s Under Construction Badge -->
       <div class="under-construction">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -161,19 +161,27 @@
     </div>
     <div class="header-right">
       <nav class="nav" id="main-nav" role="navigation" aria-label="Main navigation">
-        <a href="#projects" class="nav-link" data-section="01">
+        <a href="#now" class="nav-link" data-section="01">
           <span class="nav-prefix"></span>
-          <span class="nav-text" data-i18n="nav.projects">Projects</span>
+          <span class="nav-text" data-i18n="nav.now">Now</span>
         </a>
-        <a href="#about" class="nav-link" data-section="02">
+        <a href="#work" class="nav-link" data-section="02">
           <span class="nav-prefix"></span>
-          <span class="nav-text" data-i18n="nav.about">About</span>
+          <span class="nav-text" data-i18n="nav.work">Work</span>
         </a>
-        <a href="#timeline" class="nav-link" data-section="03">
+        <a href="#writing" class="nav-link" data-section="03">
+          <span class="nav-prefix"></span>
+          <span class="nav-text" data-i18n="nav.writing">Writing</span>
+        </a>
+        <a href="#timeline" class="nav-link" data-section="04">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.history">History</span>
         </a>
-        <a href="#contact" class="nav-link" data-section="05">
+        <a href="#about" class="nav-link" data-section="05">
+          <span class="nav-prefix"></span>
+          <span class="nav-text" data-i18n="nav.about">About</span>
+        </a>
+        <a href="#contact" class="nav-link" data-section="06">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.contact">Contact</span>
         </a>
@@ -332,13 +340,13 @@
     </div>
   </section>
 
-  <!-- Projects Section -->
-  <section id="projects" class="projects">
+  <!-- Work Section (formerly Projects) -->
+  <section id="work" class="projects work">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">01</span>
+        <span class="section-number">02</span>
         <span class="section-prompt">$</span>
-        <h2 class="section-title" data-glitch="PROJECTS" data-i18n="sections.projects">PROJECTS</h2><span class="retro-badge" data-i18n="blog.newBadge">NEW!</span>
+        <h2 class="section-title" data-glitch="WORK" data-i18n="sections.work">WORK</h2><span class="retro-badge" data-i18n="blog.newBadge">NEW!</span>
       </div>
       <div class="section-divider">═══════════════════════════════════════════════════════</div>
     </div>
@@ -360,7 +368,7 @@
   <section id="about" class="about">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">02</span>
+        <span class="section-number">05</span>
         <span class="section-prompt">$</span>
         <h2 class="section-title" data-glitch="ABOUT" data-i18n="sections.about">ABOUT</h2>
       </div>
@@ -410,7 +418,7 @@
   <section id="timeline" class="git-timeline-section">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">03</span>
+        <span class="section-number">04</span>
         <span class="section-prompt">$</span>
         <h2 class="section-title" data-glitch="HISTORY" data-i18n="sections.history">HISTORY</h2>
       </div>
@@ -468,7 +476,7 @@
   <section id="contact" class="contact">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">04</span>
+        <span class="section-number">06</span>
         <span class="section-prompt">$</span>
         <h2 class="section-title" data-glitch="CONTACT" data-i18n="sections.contact">CONTACT</h2>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -358,7 +358,7 @@
           <span class="now-date" id="now-date" data-content="now.date">avril 2026</span>
         </div>
         <div class="card-body">
-          <p class="code-comment now-intro"><span data-i18n="now.intro">Section vivante. Mise à jour quand ça bouge.</span></p>
+          <p class="now-intro"><span class="code-comment-marker">/* </span><span data-i18n="now.intro">Section vivante. Mise à jour quand ça bouge.</span><span class="code-comment-marker"> */</span></p>
           <ul class="now-list" id="now-list">
             <li class="now-list-loading" data-i18n="ui.loadingNow">Chargement...</li>
           </ul>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -488,16 +488,18 @@
     </div>
   </section>
 
-  <!-- Blog Section (commented out - enable later if needed)
-  <section id="blog" class="blog">
+  <!-- Writing Section (blog excerpts on home) -->
+  <section id="writing" class="blog writing">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">04</span>
+        <span class="section-number">03</span>
         <span class="section-prompt">$</span>
-        <h2 class="section-title" data-glitch="BLOG" data-i18n="sections.blog">BLOG</h2><span class="retro-badge" data-i18n="blog.newBadge">NEW!</span>
+        <h2 class="section-title" data-glitch="WRITING" data-i18n="sections.writing">WRITING</h2>
       </div>
       <div class="section-divider">═══════════════════════════════════════════════════════</div>
     </div>
+
+    <p class="writing-intro" data-i18n="writing.intro">Notes, posts, et ce que j'apprends en construisant.</p>
 
     <div id="blog-grid" class="blog-grid">
       <div class="blog-grid-loading">
@@ -516,7 +518,6 @@
       </a>
     </div>
   </section>
-  -->
 
   <!-- Contact Section -->
   <section id="contact" class="contact">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -378,15 +378,34 @@
       <div class="section-divider">═══════════════════════════════════════════════════════</div>
     </div>
 
-    <div id="projects-grid" class="projects-grid">
-      <div class="projects-grid-loading">
-        <span class="loading-text" data-i18n="ui.loadingProjects">Loading projects...</span>
-        <span class="loading-spinner">⣾⣽⣻⢿⡿⣟⣯⣷</span>
+    <!-- Hidden legacy grid (kept for back-compat with theme-init renderProjects fallback) -->
+    <div id="projects-grid" class="projects-grid projects-grid-hidden" hidden></div>
+
+    <!-- Territory 1: Product Builder -->
+    <div class="work-territory" id="territory-product-builder">
+      <header class="work-territory-header">
+        <h3 class="work-territory-title" data-i18n="work.productBuilder.title">PRODUCT BUILDER</h3>
+        <p class="work-territory-subtitle" data-i18n="work.productBuilder.subtitle">Lead Front-End @ CBA · AgatheYOU · side projects.</p>
+      </header>
+      <div id="work-product-builder-grid" class="projects-grid">
+        <div class="projects-grid-loading">
+          <span class="loading-text" data-i18n="ui.loadingProjects">Chargement des projets...</span>
+          <span class="loading-spinner">⣾⣽⣻⢿⡿⣟⣯⣷</span>
+        </div>
       </div>
     </div>
 
+    <!-- Territory 2: Transformation IA -->
+    <div class="work-territory" id="territory-transformation-ia">
+      <header class="work-territory-header">
+        <h3 class="work-territory-title" data-i18n="work.transformationIa.title">TRANSFORMATION IA</h3>
+        <p class="work-territory-subtitle" data-i18n="work.transformationIa.subtitle">Plateforme & IA agentique chez CBA, agence IA chez Studio Manifeste.</p>
+      </header>
+      <div id="work-transformation-ia-grid" class="projects-grid"></div>
+    </div>
+
     <div class="section-footer">
-      <span class="footer-info">total 4 projects | drwxr-xr-x</span>
+      <span class="footer-info" id="work-footer-info">total — | drwxr-xr-x</span>
       <span class="coord-marker">x: 0, y: 1200</span>
     </div>
   </section>

--- a/frontend/js/components/header.js
+++ b/frontend/js/components/header.js
@@ -15,18 +15,22 @@ const HeaderComponent = (() => {
 
     // Default navigation items
     const DEFAULT_NAV_ITEMS = [
-        { href: '/#projects', section: '01', i18nKey: 'nav.projects', text: 'Projects' },
-        { href: '/#about', section: '02', i18nKey: 'nav.about', text: 'About' },
-        { href: '/#timeline', section: '03', i18nKey: 'nav.history', text: 'History' },
-        { href: '/#contact', section: '05', i18nKey: 'nav.contact', text: 'Contact' }
+        { href: '/#now', section: '01', i18nKey: 'nav.now', text: 'Now' },
+        { href: '/#work', section: '02', i18nKey: 'nav.work', text: 'Work' },
+        { href: '/#writing', section: '03', i18nKey: 'nav.writing', text: 'Writing' },
+        { href: '/#timeline', section: '04', i18nKey: 'nav.history', text: 'History' },
+        { href: '/#about', section: '05', i18nKey: 'nav.about', text: 'About' },
+        { href: '/#contact', section: '06', i18nKey: 'nav.contact', text: 'Contact' }
     ];
 
     // Navigation items for landing page (internal links)
     const LANDING_NAV_ITEMS = [
-        { href: '#projects', section: '01', i18nKey: 'nav.projects', text: 'Projects' },
-        { href: '#about', section: '02', i18nKey: 'nav.about', text: 'About' },
-        { href: '#timeline', section: '03', i18nKey: 'nav.history', text: 'History' },
-        { href: '#contact', section: '05', i18nKey: 'nav.contact', text: 'Contact' }
+        { href: '#now', section: '01', i18nKey: 'nav.now', text: 'Now' },
+        { href: '#work', section: '02', i18nKey: 'nav.work', text: 'Work' },
+        { href: '#writing', section: '03', i18nKey: 'nav.writing', text: 'Writing' },
+        { href: '#timeline', section: '04', i18nKey: 'nav.history', text: 'History' },
+        { href: '#about', section: '05', i18nKey: 'nav.about', text: 'About' },
+        { href: '#contact', section: '06', i18nKey: 'nav.contact', text: 'Contact' }
     ];
 
     /**

--- a/frontend/js/core/card-renderer.js
+++ b/frontend/js/core/card-renderer.js
@@ -53,11 +53,19 @@ const CardRenderer = (() => {
 
     function renderProjectCard(project, index, config = {}) {
         const cfg = { ...defaultConfig.project, ...config };
-        const card = document.createElement('a');
+        const hasUrl = Boolean(project.url);
+        const card = document.createElement(hasUrl ? 'a' : 'div');
         card.className = cfg.wrapperClass + (cfg.extraClasses ? ' ' + cfg.extraClasses : '');
-        card.href = project.url;
-        card.target = '_blank';
-        card.rel = 'noopener noreferrer';
+        if (hasUrl) {
+            card.href = project.url;
+            card.target = '_blank';
+            card.rel = 'noopener noreferrer';
+        } else {
+            card.classList.add('no-url');
+        }
+        if (!project.images?.length && !project.video) {
+            card.classList.add('no-image');
+        }
 
         if (cfg.animationDelay) card.style.animationDelay = `${index * 0.1}s`;
         if (cfg.tooltip) card.setAttribute('data-tooltip', cfg.tooltip.replace('{title}', project.title));
@@ -69,7 +77,7 @@ const CardRenderer = (() => {
         let header = cfg.headerTemplate ? cfg.headerTemplate(project, idx)
             : (cfg.showIndex || cfg.showType) ? `<div class="project-card-header">${cfg.showIndex ? `<span class="project-index">${cfg.indexPrefix}${idx}</span>` : ''}${cfg.showType ? `<span class="project-type">${cfg.typePrefix}${project.type}${cfg.typeSuffix}</span>` : ''}</div>` : '';
 
-        let url = cfg.showUrl ? `<div class="project-link"><span class="link-icon">${cfg.urlIcon}</span><span class="link-url">${cfg.urlText || project.url}</span></div>` : '';
+        let url = (cfg.showUrl && hasUrl) ? `<div class="project-link"><span class="link-icon">${cfg.urlIcon}</span><span class="link-url">${cfg.urlText || project.url}</span></div>` : '';
         let footer = cfg.footerTemplate ? cfg.footerTemplate(project, idx) : '';
         let corners = cfg.cornerDecorations ? '<div class="card-corner tl"></div><div class="card-corner tr"></div><div class="card-corner bl"></div><div class="card-corner br"></div>' : '';
 

--- a/frontend/js/core/content-loader.js
+++ b/frontend/js/core/content-loader.js
@@ -139,6 +139,11 @@ const ContentLoader = (() => {
         if (window.LanguageManager && !LanguageManager.isLoaded) {
             await LanguageManager.init();
         }
+        // Load theme-scoped translations now that LanguageManager is ready
+        const themeId = window.ThemeManager?.getCurrentThemeId?.();
+        if (themeId && window.LanguageManager?.loadThemeTranslations) {
+            await LanguageManager.loadThemeTranslations(themeId, LanguageManager.currentLang);
+        }
         await loadContent();
         await loadNow();
         if (window.LanguageManager?.isLoaded) {

--- a/frontend/js/core/content-loader.js
+++ b/frontend/js/core/content-loader.js
@@ -7,7 +7,8 @@ const ContentLoader = (() => {
     let siteContent = {};
     let projects = [];
     let articles = [];
-    let loaded = { content: false, projects: false, articles: false };
+    let nowData = null;
+    let loaded = { content: false, projects: false, articles: false, now: false };
 
     const getCurrentLang = () => window.LanguageManager?.currentLang || 'fr';
 
@@ -68,15 +69,83 @@ const ContentLoader = (() => {
         });
     }
 
+    async function loadNow() {
+        if (loaded.now) return nowData;
+
+        const lang = getCurrentLang();
+        try {
+            const response = await fetch(`/data/${lang}/now.json`);
+            if (!response.ok) throw new Error('Failed to fetch now');
+            nowData = await response.json();
+            loaded.now = true;
+            console.log(`%c[OK] /now loaded (${lang})`, 'color: #33ff00;');
+        } catch (err) {
+            console.warn('[WARN] /now data unavailable');
+            nowData = null;
+        }
+        return nowData;
+    }
+
+    function populateNow() {
+        if (!nowData) return;
+
+        const dateEl = document.getElementById('now-date');
+        if (dateEl && nowData.date) dateEl.textContent = nowData.date;
+
+        const list = document.getElementById('now-list');
+        if (!list || !Array.isArray(nowData.items)) return;
+
+        list.textContent = '';
+        nowData.items.forEach(item => {
+            const li = document.createElement('li');
+            li.className = 'now-item';
+            if (item.key) li.dataset.nowKey = item.key;
+
+            const arrow = document.createElement('span');
+            arrow.className = 'now-arrow';
+            arrow.textContent = '→';
+
+            const label = document.createElement('span');
+            label.className = 'now-label';
+            label.textContent = item.label || '';
+
+            const value = document.createElement('span');
+            value.className = 'now-value';
+            value.textContent = item.value || '';
+
+            if (item.link && item.link.url) {
+                value.appendChild(document.createTextNode(' '));
+                const a = document.createElement('a');
+                a.className = 'now-link';
+                a.href = item.link.url;
+                a.target = '_blank';
+                a.rel = 'noopener noreferrer';
+                a.textContent = item.link.text || item.link.url;
+                const arrowOut = document.createElement('span');
+                arrowOut.className = 'now-link-arrow';
+                arrowOut.textContent = '↗';
+                a.appendChild(arrowOut);
+                value.appendChild(a);
+            }
+
+            li.appendChild(arrow);
+            li.appendChild(label);
+            li.appendChild(value);
+            list.appendChild(li);
+        });
+    }
+
     async function loadAndPopulate() {
         if (window.LanguageManager && !LanguageManager.isLoaded) {
             await LanguageManager.init();
         }
         await loadContent();
+        await loadNow();
         if (window.LanguageManager?.isLoaded) {
             LanguageManager.populateTranslations();
         }
         populateContent();
+        populateNow();
         return siteContent;
     }
 
@@ -132,7 +201,8 @@ const ContentLoader = (() => {
         siteContent = {};
         projects = [];
         articles = [];
-        loaded = { content: false, projects: false, articles: false };
+        nowData = null;
+        loaded = { content: false, projects: false, articles: false, now: false };
     }
 
     return {
@@ -140,11 +210,13 @@ const ContentLoader = (() => {
         loadAndPopulate,
         loadProjects,
         loadArticles,
+        loadNow,
         formatDate,
         resetCache,
         get content() { return siteContent; },
         get projects() { return projects; },
         get articles() { return articles; },
+        get now() { return nowData; },
         get isLoaded() { return loaded.content; }
     };
 })();

--- a/frontend/js/core/theme-init.js
+++ b/frontend/js/core/theme-init.js
@@ -13,7 +13,30 @@ const ThemeInit = (() => {
             await ContentLoader.loadAndPopulate();
 
             const projects = await ContentLoader.loadProjects();
-            CardRenderer.renderProjects(projects, config.cards || {}, '#projects-grid');
+            const builderProjects = projects.filter(p => p.category === 'product-builder');
+            const transformProjects = projects.filter(p => p.category === 'transformation-ia');
+
+            if (document.querySelector('#work-product-builder-grid')) {
+                CardRenderer.renderProjects(builderProjects, config.cards || {}, '#work-product-builder-grid');
+            }
+            if (document.querySelector('#work-transformation-ia-grid')) {
+                CardRenderer.renderProjects(transformProjects, config.cards || {}, '#work-transformation-ia-grid');
+            }
+
+            // Back-compat: if a legacy single grid is present, render all there.
+            const legacyGrid = document.querySelector('#projects-grid:not(.projects-grid-hidden)');
+            if (legacyGrid) {
+                CardRenderer.renderProjects(projects, config.cards || {}, '#projects-grid');
+            }
+
+            const footerInfo = document.querySelector('#work-footer-info');
+            if (footerInfo) {
+                const total = projects.length;
+                const lang = window.LanguageManager?.currentLang || 'fr';
+                const word = lang === 'fr' ? 'projets' : 'projects';
+                footerInfo.textContent = `total ${total} ${word} | drwxr-xr-x`;
+            }
+
             Carousel.initAll();
 
             ScrollEffects.initAll();

--- a/frontend/themes/blueprint/blueprint.css
+++ b/frontend/themes/blueprint/blueprint.css
@@ -450,7 +450,7 @@ body[data-theme="blueprint"] .section-title::before {
   font-size: clamp(1.2rem, 3vw, 1.8rem); /* Restore font size for pseudo-element */
 }
 
-body[data-theme="blueprint"] #projects .section-title::before {
+body[data-theme="blueprint"] #work .section-title::before {
   content: 'SELECTED WORKS';
 }
 


### PR DESCRIPTION
## Summary

Repositionnement éditorial complet de tomandrieu.com pour refléter le double positionnement actuel :

- **Product Builder** — Lead Front-End @ CBA AgatheYOU + side projects
- **Transformation IA** — Platform Architect @ CBA (mission 6 mois) + Studio Manifeste

Le site reste un **manifeste personnel**, pas une vitrine commerciale. Studio Manifeste reste linké en externe vers `studio.alphaluppi.fr` sans dupliquer son contenu.

## What changed

### Structure éditoriale
- **Hero** : `PRODUCT ENGINEER / BUILDING THINGS THAT MATTER` → `SALUT` (`HEY` en EN) + citation manifeste 5 lignes
- **Nav** : `Projects · About · History · Contact` → `Now · Work · Writing · History · About · Contact`
- **/now** (NEW) : section vivante datée (`avril 2026`), source `data/{fr,en}/now.json`, format `→ Build / Transform / Studio / Freelance`
- **Work** : flat grid → 2 territoires empilés (Product Builder + Transformation IA), avec AgatheYOU, Platform Architect @ CBA, Studio Manifeste comme nouvelles cartes
- **Writing** : section blog réactivée en home (3 derniers articles + CTA `View all`)
- **Contact** : retrait du badge `Currently accepting new clients for Q2 2025` (périmé, /now est désormais la source de vérité)
- **Timeline** : nouvelle branche Studio Manifeste (2026-01) + nouveau commit Platform Architect sur la branche CBA (2026-04)

### Sous le capot
- `card-renderer.js` : cartes sans URL → rendues comme `<div>` au lieu de `<a>` (ex: Platform Architect, AgatheYOU)
- `content-loader.js` : `loadNow()` + `populateNow()` (DOM-safe, pas d'innerHTML pour le contenu) ; charge `themeTranslations` après `LanguageManager.init()` pour que les keys i18n thème soient résolues au premier rendu
- `language-manager.js` : `populateTranslations()` skip les éléments dont la traduction tombe sur la key (préserve le fallback HTML)
- i18n : nouvelles entrées `nav.{now,work,writing}`, `sections.{now,work,writing}`, `now.*`, `work.{productBuilder,transformationIa}.*`, `writing.intro`, `ui.openToConversations`

### Préservé
- Les 4 thèmes (default, terminal, blueprint, retro90s) + le switcher
- La timeline git flow (carrière en branches/commits)
- Le ton perso

## Test plan

- [x] Test visuel `default` FR — hero, /now, work territories, writing, contact
- [x] Test visuel `terminal` FR — ASCII art, terminal output traduit (\"CHARGEMENT DES MODULES\" / \"PRODUCT BUILDER INITIALISÉ\"), /now en uppercase avec markers `/* */`
- [x] Test visuel `blueprint` FR — typo blanche sur bleu marine, citation lettre-espacée, nav numérotée 01-06
- [x] Test visuel `retro90s` FR — vert relief, Comic Sans, nav Windows 95
- [x] Studio Manifeste link → externe avec icône ↗
- [ ] Test EN sur les 4 thèmes (recommandé avant merge)
- [ ] Mobile responsive sur les 4 thèmes
- [ ] Vérifier le SSR sur staging (Traefik labels, build Docker)

## Files to edit post-merge

- `data/{fr,en}/now.json` — éditer manuellement quand l'état change (mois 1/6 → 2/6, etc.)
- `data/{fr,en}/projects.json` — ajouter images pour AgatheYOU / Platform Architect / Studio Manifeste si désiré