### PR TITLE
copy(home): dedupe + rewrite hero/now/work/about in Tom's voice

### DIFF
--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -910,16 +910,23 @@ body[data-theme="terminal"] .code-comment-marker {
   opacity: 0.7;
 }
 
-/* ─── Hero Quote (multi-line manifesto) ─── */
+/* ─── Hero Quote (intro paragraph, left-aligned) ─── */
 .hero-quote {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.1rem;
-  text-align: center;
+  display: block;
+  max-width: 640px;
+  margin: 0 auto var(--spacing-lg);
+  text-align: left;
   position: relative;
 }
 
+.hero-quote-paragraph {
+  margin: 0;
+  line-height: 1.7;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Legacy multi-line rules kept for back-compat with any cached HTML */
 .hero-quote-line {
   margin: 0;
   line-height: 1.6;

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -565,11 +565,88 @@ body.loading * {
   gap: 1rem;
 }
 
-/* ─── Tech Grid ─── */
+/* ─── Tech Grid (legacy, kept for back-compat) ─── */
 .tech-grid {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+/* ─── Craft block (replaces tech grid) ─── */
+.craft-stack {
+  margin-top: 1rem;
+}
+
+.craft-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-left: 2px solid currentColor;
+  border-color: var(--accent, currentColor);
+  opacity: 0.95;
+}
+
+.craft-title {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--accent, inherit);
+}
+
+.craft-description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+/* ─── /now paragraph (replaces 4-bucket list) ─── */
+.now-paragraph {
+  margin: 0;
+  line-height: 1.65;
+  font-size: 1rem;
+}
+
+.now-inline-link {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  color: inherit;
+}
+
+.now-paragraph-loading {
+  opacity: 0.5;
+  font-style: italic;
+}
+
+/* ─── Compact (no-image) project cards: 2-up grid in same row ─── */
+.project-card.no-image {
+  grid-column: span 1;
+  position: relative;
+}
+
+.project-card.no-image .project-media-container {
+  display: none;
+}
+
+/* Small type badge in the top-right so the card reads as an intentional
+   "text mission" tile instead of a broken image card */
+.project-card.no-image::before {
+  content: attr(data-card-type);
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border: 1px dashed currentColor;
+  border-radius: 999px;
+  opacity: 0.55;
+  pointer-events: none;
 }
 
 /* ─── Responsive social links fix ─── */

--- a/frontend/data/en/content.json
+++ b/frontend/data/en/content.json
@@ -20,7 +20,7 @@
   },
   "craft": {
     "title": "AI POWERED",
-    "description": "No stack resists me anymore. With AI, I can build apps in any language, any framework, any platform. A bit pretentious, but it's true."
+    "description": "AI made me stack-agnostic. Language, framework or platform: I pick what fits the problem, not what I already knew."
   },
   "contact": {
     "email": "CONTACT@TOMANDRIEU.COM",

--- a/frontend/data/en/content.json
+++ b/frontend/data/en/content.json
@@ -2,26 +2,20 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · AI Transformation",
-    "description": "Product Builder and AI Transformation. I build products, and I transform with AI the teams that build products."
+    "description": "I build products, and I help product teams fold AI into their day-to-day work. CBA · Studio Manifeste."
   },
   "hero": {
     "title": "HEY",
-    "quote": [
-      "I'm a product builder.",
-      "But by building with AI,",
-      "I started transforming the teams",
-      "who build products.",
-      "Now I do both."
-    ]
+    "quote": "I've been coding for 8 years. My job is building products. AI didn't change that craft, it changed who can do it and how fast. From building with it, I ended up helping other teams fold it into their day-to-day work. Same craft, two angles."
   },
   "about": {
-    "intro": "I build <highlight>PRODUCTS</highlight>, and I transform with <highlight>AI</highlight> the teams who build them.",
-    "detail": "Build side: Lead Front-End @ CBA (AgatheYOU) and side projects. Transform side: Platform Architect @ CBA (6-month mission on the platform & agentic AI) and co-founder of Studio Manifeste, the AI agency for SMEs. Same craft, two sides.",
+    "intro": "I think you learn a craft <highlight>by doing it</highlight>, and you learn to transform a craft <highlight>by having done it</highlight>.",
+    "detail": "On craft, I prefer short iterations over closed specs, pairs over committees, and tools you understand over tools you put up with. AI didn't change that preference. It just made it apply to more problems, faster.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ YEARS",
-      "focus": "PRODUCT BUILDER · AGENTIC AI",
-      "status": "ON MISSION"
+      "focus": "ARCHITECTURE · AI · PRODUCT",
+      "status": "6-MONTH MISSION · M1/6"
     }
   },
   "techStack": [

--- a/frontend/data/en/content.json
+++ b/frontend/data/en/content.json
@@ -10,25 +10,18 @@
   },
   "about": {
     "intro": "I think you learn a craft <highlight>by doing it</highlight>, and you learn to transform a craft <highlight>by having done it</highlight>.",
-    "detail": "On craft, I prefer short iterations over closed specs, pairs over committees, and tools you understand over tools you put up with. AI didn't change that preference. It just made it apply to more problems, faster.",
+    "detail": "I prefer short iterations over closed specs, pairs over committees, and tools you understand over tools you put up with. AI didn't change that preference. It just made it apply to more problems, faster.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ YEARS",
       "focus": "ARCHITECTURE · AI · PRODUCT",
-      "status": "6-MONTH MISSION · M1/6"
+      "status": "BUILDING"
     }
   },
-  "techStack": [
-    "AI/ML",
-    "NEXT.JS",
-    "ANGULAR",
-    "TYPESCRIPT",
-    "NODE.JS",
-    "NESTJS",
-    "FLUTTER",
-    "WORDPRESS",
-    "VOXEL"
-  ],
+  "craft": {
+    "title": "AI POWERED",
+    "description": "No stack resists me anymore. With AI, I can build apps in any language, any framework, any platform. A bit pretentious, but it's true."
+  },
   "contact": {
     "email": "CONTACT@TOMANDRIEU.COM",
     "social": {

--- a/frontend/data/en/now.json
+++ b/frontend/data/en/now.json
@@ -6,17 +6,17 @@
     {
       "key": "build",
       "label": "Build",
-      "value": "Lead Front-End @ CBA · AgatheYOU · side projects."
+      "value": "AgatheYOU keeps shipping in prod. Two side projects on the side."
     },
     {
       "key": "transform",
       "label": "Transform",
-      "value": "Platform Architect @ CBA · month 1/6 — platform & agentic AI for product and tech teams."
+      "value": "Month 1/6 of a Platform Architect mission: equipping CBA teams with agentic AI."
     },
     {
       "key": "studio",
       "label": "Studio",
-      "value": "Studio Manifeste — the AI agency for SMEs, in the works.",
+      "value": "Studio Manifeste, the AI agency for SMEs, in the works.",
       "link": {
         "url": "https://studio.alphaluppi.fr",
         "text": "studio.alphaluppi.fr"
@@ -25,7 +25,7 @@
     {
       "key": "freelance",
       "label": "Freelance",
-      "value": "No open mission right now."
+      "value": "No open window this quarter."
     }
   ]
 }

--- a/frontend/data/en/now.json
+++ b/frontend/data/en/now.json
@@ -2,30 +2,9 @@
   "date": "April 2026",
   "headerLabel": "WHERE I'M AT",
   "intro": "Living section. Updated when things move.",
-  "items": [
-    {
-      "key": "build",
-      "label": "Build",
-      "value": "AgatheYOU keeps shipping in prod. Two side projects on the side."
-    },
-    {
-      "key": "transform",
-      "label": "Transform",
-      "value": "Month 1/6 of a Platform Architect mission: equipping CBA teams with agentic AI."
-    },
-    {
-      "key": "studio",
-      "label": "Studio",
-      "value": "Studio Manifeste, the AI agency for SMEs, in the works.",
-      "link": {
-        "url": "https://studio.alphaluppi.fr",
-        "text": "studio.alphaluppi.fr"
-      }
-    },
-    {
-      "key": "freelance",
-      "label": "Freelance",
-      "value": "No open window this quarter."
-    }
+  "paragraph": [
+    { "text": "Last month I took on a 6-month mission on top of the Lead Front-End role: Platform Architect at CBA, working on the dev platform and agentic AI for product and tech teams. AgatheYOU keeps shipping. " },
+    { "link": { "text": "Studio Manifeste", "url": "https://studio.alphaluppi.fr" } },
+    { "text": ", the AI agency I'm co-founding, is taking shape on the side. Two side projects in the oven, no freelance window this quarter." }
   ]
 }

--- a/frontend/data/en/projects.json
+++ b/frontend/data/en/projects.json
@@ -1,13 +1,5 @@
 [
     {
-        "id": "agatheyou",
-        "title": "AgatheYOU",
-        "description": "Lead Front-End on AgatheYOU @ CBA. Health app for liberal practitioners, Angular & Ionic, team of 8 developers.",
-        "type": "PRODUCT (CBA)",
-        "category": "product-builder",
-        "tags": ["Angular", "Ionic", "Lead Front-End", "Healthcare"]
-    },
-    {
         "id": "ride-my-park",
         "title": "Ride My Park",
         "description": "Find nearby spots among 30K skateparks, street spots & pumptracks for BMX, Skateboard, Aggressive Inline, Freestyle Scooter on Ride My Park.",

--- a/frontend/data/fr/content.json
+++ b/frontend/data/fr/content.json
@@ -2,26 +2,20 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · Transformation IA",
-    "description": "Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits."
+    "description": "Je construis des produits, et j'aide les équipes qui en construisent à intégrer l'IA dans leur quotidien. CBA · Studio Manifeste."
   },
   "hero": {
     "title": "SALUT",
-    "quote": [
-      "Je suis product builder.",
-      "Mais à force de construire avec l'IA,",
-      "j'ai commencé à transformer les équipes",
-      "qui construisent des produits.",
-      "Maintenant je fais les deux."
-    ]
+    "quote": "Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien. Même métier, deux angles."
   },
   "about": {
-    "intro": "Je construis des <highlight>PRODUITS</highlight>, et je transforme par l'<highlight>IA</highlight> les équipes qui en construisent.",
-    "detail": "Côté build : Lead Front-End @ CBA (AgatheYOU) et side projects. Côté transformation : Platform Architect @ CBA (mission 6 mois sur la plateforme & IA agentique) et co-fondateur du Studio Manifeste, l'agence IA pour PME. C'est le même métier, vu de deux côtés.",
+    "intro": "Je crois qu'on apprend un métier <highlight>en le faisant</highlight>, et qu'on apprend à le transformer <highlight>en l'ayant fait</highlight>.",
+    "detail": "Côté craft, je préfère les itérations courtes aux specs fermées, les binômes aux comités, et les outils qu'on comprend aux outils qu'on subit. L'IA n'a pas changé cette préférence, elle l'a juste rendue applicable à plus de problèmes, plus vite.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ ANS",
-      "focus": "PRODUCT BUILDER · IA AGENTIQUE",
-      "status": "MISSION EN COURS"
+      "focus": "ARCHITECTURE · IA · PRODUIT",
+      "status": "MISSION 6 MOIS · M1/6"
     }
   },
   "techStack": [

--- a/frontend/data/fr/content.json
+++ b/frontend/data/fr/content.json
@@ -20,7 +20,7 @@
   },
   "craft": {
     "title": "AI POWERED",
-    "description": "Plus aucune stack ne me résiste. Avec l'IA, je peux faire des apps dans n'importe quel langage, n'importe quel framework, n'importe quelle plateforme. Un peu prétentieux, mais c'est vrai."
+    "description": "L'IA m'a rendu stack-agnostic. Le langage, le framework ou la plateforme : je choisis selon le problème à résoudre, pas selon ce que je maîtrisais avant."
   },
   "contact": {
     "email": "CONTACT@TOMANDRIEU.COM",

--- a/frontend/data/fr/content.json
+++ b/frontend/data/fr/content.json
@@ -10,25 +10,18 @@
   },
   "about": {
     "intro": "Je crois qu'on apprend un métier <highlight>en le faisant</highlight>, et qu'on apprend à le transformer <highlight>en l'ayant fait</highlight>.",
-    "detail": "Côté craft, je préfère les itérations courtes aux specs fermées, les binômes aux comités, et les outils qu'on comprend aux outils qu'on subit. L'IA n'a pas changé cette préférence, elle l'a juste rendue applicable à plus de problèmes, plus vite.",
+    "detail": "Je préfère les itérations courtes aux specs fermées, les binômes aux comités, et les outils qu'on comprend aux outils qu'on subit. L'IA n'a pas changé cette préférence, elle l'a juste rendue applicable à plus de problèmes, plus vite.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ ANS",
       "focus": "ARCHITECTURE · IA · PRODUIT",
-      "status": "MISSION 6 MOIS · M1/6"
+      "status": "EN BUILD"
     }
   },
-  "techStack": [
-    "IA/ML",
-    "NEXT.JS",
-    "ANGULAR",
-    "TYPESCRIPT",
-    "NODE.JS",
-    "NESTJS",
-    "FLUTTER",
-    "WORDPRESS",
-    "VOXEL"
-  ],
+  "craft": {
+    "title": "AI POWERED",
+    "description": "Plus aucune stack ne me résiste. Avec l'IA, je peux faire des apps dans n'importe quel langage, n'importe quel framework, n'importe quelle plateforme. Un peu prétentieux, mais c'est vrai."
+  },
   "contact": {
     "email": "CONTACT@TOMANDRIEU.COM",
     "social": {

--- a/frontend/data/fr/now.json
+++ b/frontend/data/fr/now.json
@@ -2,30 +2,9 @@
   "date": "avril 2026",
   "headerLabel": "OÙ J'EN SUIS",
   "intro": "Section vivante. Mise à jour quand ça bouge.",
-  "items": [
-    {
-      "key": "build",
-      "label": "Build",
-      "value": "AgatheYOU continue d'évoluer en prod. Deux side projects en parallèle."
-    },
-    {
-      "key": "transform",
-      "label": "Transform",
-      "value": "Mois 1/6 d'une mission Platform Architect : outiller les équipes CBA en IA agentique."
-    },
-    {
-      "key": "studio",
-      "label": "Studio",
-      "value": "Studio Manifeste, l'agence IA pour PME, en construction.",
-      "link": {
-        "url": "https://studio.alphaluppi.fr",
-        "text": "studio.alphaluppi.fr"
-      }
-    },
-    {
-      "key": "freelance",
-      "label": "Freelance",
-      "value": "Pas de fenêtre ouverte ce trimestre."
-    }
+  "paragraph": [
+    { "text": "Le mois dernier j'ai pris une mission de 6 mois en plus du Lead Front-End : Platform Architect chez CBA, sur la plateforme dev et l'IA agentique pour les équipes produit et tech. AgatheYOU continue d'évoluer en prod. " },
+    { "link": { "text": "Studio Manifeste", "url": "https://studio.alphaluppi.fr" } },
+    { "text": ", l'agence IA qu'on co-fonde, prend forme en parallèle. Deux side projects sur le feu, pas de fenêtre freelance ce trimestre." }
   ]
 }

--- a/frontend/data/fr/now.json
+++ b/frontend/data/fr/now.json
@@ -6,17 +6,17 @@
     {
       "key": "build",
       "label": "Build",
-      "value": "Lead Front-End @ CBA · AgatheYOU · side projects."
+      "value": "AgatheYOU continue d'évoluer en prod. Deux side projects en parallèle."
     },
     {
       "key": "transform",
       "label": "Transform",
-      "value": "Platform Architect @ CBA · mois 1/6 — plateforme & IA agentique pour les équipes produit et tech."
+      "value": "Mois 1/6 d'une mission Platform Architect : outiller les équipes CBA en IA agentique."
     },
     {
       "key": "studio",
       "label": "Studio",
-      "value": "Studio Manifeste — l'agence IA pour PME, en construction.",
+      "value": "Studio Manifeste, l'agence IA pour PME, en construction.",
       "link": {
         "url": "https://studio.alphaluppi.fr",
         "text": "studio.alphaluppi.fr"
@@ -25,7 +25,7 @@
     {
       "key": "freelance",
       "label": "Freelance",
-      "value": "Pas de mission ouverte pour le moment."
+      "value": "Pas de fenêtre ouverte ce trimestre."
     }
   ]
 }

--- a/frontend/data/fr/projects.json
+++ b/frontend/data/fr/projects.json
@@ -1,13 +1,5 @@
 [
     {
-        "id": "agatheyou",
-        "title": "AgatheYOU",
-        "description": "Lead Front-End sur AgatheYOU @ CBA. Application santé pour les professionnels libéraux, Angular & Ionic, équipe de 8 développeurs.",
-        "type": "PRODUIT (CBA)",
-        "category": "product-builder",
-        "tags": ["Angular", "Ionic", "Lead Front-End", "Santé"]
-    },
-    {
         "id": "ride-my-park",
         "title": "Ride My Park",
         "description": "Trouvez des spots près de chez vous parmi 30K skateparks, street spots et pumptracks pour BMX, Skateboard, Roller, Trottinette Freestyle sur Ride My Park.",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -26,7 +26,7 @@
   },
   "craft": {
     "title": "AI POWERED",
-    "description": "No stack resists me anymore. With AI, I can build apps in any language, any framework, any platform. A bit pretentious, but it's true."
+    "description": "AI made me stack-agnostic. Language, framework or platform: I pick what fits the problem, not what I already knew."
   },
   "techStack": [
     "AI/ML",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -2,26 +2,20 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · AI Transformation",
-    "description": "Product Builder and AI Transformation. I build products, and I transform with AI the teams that build products."
+    "description": "I build products, and I help product teams fold AI into their day-to-day work. CBA · Studio Manifeste."
   },
   "hero": {
     "title": "HEY",
-    "quote": [
-      "I'm a product builder.",
-      "But by building with AI,",
-      "I started transforming the teams",
-      "who build products.",
-      "Now I do both."
-    ]
+    "quote": "I've been coding for 8 years. My job is building products. AI didn't change that craft, it changed who can do it and how fast. From building with it, I ended up helping other teams fold it into their day-to-day work. Same craft, two angles."
   },
   "about": {
-    "intro": "I build <highlight>PRODUCTS</highlight>, and I transform with <highlight>AI</highlight> the teams who build them.",
-    "detail": "Build side: Lead Front-End @ CBA (AgatheYOU) and side projects. Transform side: Platform Architect @ CBA (6-month mission on the platform & agentic AI) and co-founder of Studio Manifeste, the AI agency for SMEs. Same craft, two sides.",
+    "intro": "I think you learn a craft <highlight>by doing it</highlight>, and you learn to transform a craft <highlight>by having done it</highlight>.",
+    "detail": "On craft, I prefer short iterations over closed specs, pairs over committees, and tools you understand over tools you put up with. AI didn't change that preference. It just made it apply to more problems, faster.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ YEARS",
-      "focus": "PRODUCT BUILDER · AGENTIC AI",
-      "status": "ON MISSION"
+      "focus": "ARCHITECTURE · AI · PRODUCT",
+      "status": "6-MONTH MISSION · M1/6"
     },
     "specLabels": {
       "location": "LOCATION",
@@ -106,11 +100,11 @@
   "work": {
     "productBuilder": {
       "title": "PRODUCT BUILDER",
-      "subtitle": "Lead Front-End @ CBA · AgatheYOU · side projects."
+      "subtitle": "Products I'm building, with teams or solo."
     },
     "transformationIa": {
       "title": "AI TRANSFORMATION",
-      "subtitle": "Platform & agentic AI at CBA, AI agency at Studio Manifeste."
+      "subtitle": "Missions where I help product and tech teams fold AI into their stack."
     }
   },
   "writing": {

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -10,12 +10,12 @@
   },
   "about": {
     "intro": "I think you learn a craft <highlight>by doing it</highlight>, and you learn to transform a craft <highlight>by having done it</highlight>.",
-    "detail": "On craft, I prefer short iterations over closed specs, pairs over committees, and tools you understand over tools you put up with. AI didn't change that preference. It just made it apply to more problems, faster.",
+    "detail": "I prefer short iterations over closed specs, pairs over committees, and tools you understand over tools you put up with. AI didn't change that preference. It just made it apply to more problems, faster.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ YEARS",
       "focus": "ARCHITECTURE · AI · PRODUCT",
-      "status": "6-MONTH MISSION · M1/6"
+      "status": "BUILDING"
     },
     "specLabels": {
       "location": "LOCATION",
@@ -23,6 +23,10 @@
       "focus": "FOCUS",
       "status": "STATUS"
     }
+  },
+  "craft": {
+    "title": "AI POWERED",
+    "description": "No stack resists me anymore. With AI, I can build apps in any language, any framework, any platform. A bit pretentious, but it's true."
   },
   "techStack": [
     "AI/ML",
@@ -49,7 +53,7 @@
     "history": "History"
   },
   "sections": {
-    "now": "/NOW",
+    "now": "NOW",
     "work": "WORK",
     "writing": "WRITING",
     "projects": "PROJECTS",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -10,12 +10,12 @@
   },
   "about": {
     "intro": "Je crois qu'on apprend un métier <highlight>en le faisant</highlight>, et qu'on apprend à le transformer <highlight>en l'ayant fait</highlight>.",
-    "detail": "Côté craft, je préfère les itérations courtes aux specs fermées, les binômes aux comités, et les outils qu'on comprend aux outils qu'on subit. L'IA n'a pas changé cette préférence, elle l'a juste rendue applicable à plus de problèmes, plus vite.",
+    "detail": "Je préfère les itérations courtes aux specs fermées, les binômes aux comités, et les outils qu'on comprend aux outils qu'on subit. L'IA n'a pas changé cette préférence, elle l'a juste rendue applicable à plus de problèmes, plus vite.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ ANS",
       "focus": "ARCHITECTURE · IA · PRODUIT",
-      "status": "MISSION 6 MOIS · M1/6"
+      "status": "EN BUILD"
     },
     "specLabels": {
       "location": "LOCALISATION",
@@ -23,6 +23,10 @@
       "focus": "DOMAINE",
       "status": "STATUT"
     }
+  },
+  "craft": {
+    "title": "AI POWERED",
+    "description": "Plus aucune stack ne me résiste. Avec l'IA, je peux faire des apps dans n'importe quel langage, n'importe quel framework, n'importe quelle plateforme. Un peu prétentieux, mais c'est vrai."
   },
   "techStack": [
     "IA/ML",
@@ -49,7 +53,7 @@
     "history": "Historique"
   },
   "sections": {
-    "now": "/NOW",
+    "now": "NOW",
     "work": "WORK",
     "writing": "ÉCRITS",
     "projects": "PROJETS",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -26,7 +26,7 @@
   },
   "craft": {
     "title": "AI POWERED",
-    "description": "Plus aucune stack ne me résiste. Avec l'IA, je peux faire des apps dans n'importe quel langage, n'importe quel framework, n'importe quelle plateforme. Un peu prétentieux, mais c'est vrai."
+    "description": "L'IA m'a rendu stack-agnostic. Le langage, le framework ou la plateforme : je choisis selon le problème à résoudre, pas selon ce que je maîtrisais avant."
   },
   "techStack": [
     "IA/ML",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -2,26 +2,20 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · Transformation IA",
-    "description": "Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits."
+    "description": "Je construis des produits, et j'aide les équipes qui en construisent à intégrer l'IA dans leur quotidien. CBA · Studio Manifeste."
   },
   "hero": {
     "title": "SALUT",
-    "quote": [
-      "Je suis product builder.",
-      "Mais à force de construire avec l'IA,",
-      "j'ai commencé à transformer les équipes",
-      "qui construisent des produits.",
-      "Maintenant je fais les deux."
-    ]
+    "quote": "Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien. Même métier, deux angles."
   },
   "about": {
-    "intro": "Je construis des <highlight>PRODUITS</highlight>, et je transforme par l'<highlight>IA</highlight> les équipes qui en construisent.",
-    "detail": "Côté build : Lead Front-End @ CBA (AgatheYOU) et side projects. Côté transformation : Platform Architect @ CBA (mission 6 mois sur la plateforme & IA agentique) et co-fondateur du Studio Manifeste, l'agence IA pour PME. C'est le même métier, vu de deux côtés.",
+    "intro": "Je crois qu'on apprend un métier <highlight>en le faisant</highlight>, et qu'on apprend à le transformer <highlight>en l'ayant fait</highlight>.",
+    "detail": "Côté craft, je préfère les itérations courtes aux specs fermées, les binômes aux comités, et les outils qu'on comprend aux outils qu'on subit. L'IA n'a pas changé cette préférence, elle l'a juste rendue applicable à plus de problèmes, plus vite.",
     "specs": {
       "location": "FRANCE",
       "experience": "8+ ANS",
-      "focus": "PRODUCT BUILDER · IA AGENTIQUE",
-      "status": "MISSION EN COURS"
+      "focus": "ARCHITECTURE · IA · PRODUIT",
+      "status": "MISSION 6 MOIS · M1/6"
     },
     "specLabels": {
       "location": "LOCALISATION",
@@ -106,11 +100,11 @@
   "work": {
     "productBuilder": {
       "title": "PRODUCT BUILDER",
-      "subtitle": "Lead Front-End @ CBA · AgatheYOU · side projects."
+      "subtitle": "Produits que je construis, en équipe ou en solo."
     },
     "transformationIa": {
       "title": "TRANSFORMATION IA",
-      "subtitle": "Plateforme & IA agentique chez CBA, agence IA chez Studio Manifeste."
+      "subtitle": "Missions où j'aide des équipes produit et tech à intégrer l'IA dans leur stack."
     }
   },
   "writing": {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -275,11 +275,7 @@
 
       <div class="hero-subtitle hero-quote">
         <span class="annotation-mark hero-quote-mark-open"></span>
-        <p class="hero-quote-line" data-i18n="hero.quote.0">Je suis product builder.</p>
-        <p class="hero-quote-line" data-i18n="hero.quote.1">Mais à force de construire avec l'IA,</p>
-        <p class="hero-quote-line" data-i18n="hero.quote.2">j'ai commencé à transformer les équipes</p>
-        <p class="hero-quote-line" data-i18n="hero.quote.3">qui construisent des produits.</p>
-        <p class="hero-quote-line hero-quote-final" data-i18n="hero.quote.4">Maintenant je fais les deux.</p>
+        <p class="hero-quote-paragraph" data-i18n="hero.quote">Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien. Même métier, deux angles.</p>
         <span class="annotation-mark hero-quote-mark-close"></span>
       </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -169,19 +169,15 @@
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.work">Work</span>
         </a>
-        <a href="#writing" class="nav-link" data-section="03">
-          <span class="nav-prefix"></span>
-          <span class="nav-text" data-i18n="nav.writing">Writing</span>
-        </a>
-        <a href="#timeline" class="nav-link" data-section="04">
+        <a href="#timeline" class="nav-link" data-section="03">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.history">History</span>
         </a>
-        <a href="#about" class="nav-link" data-section="05">
+        <a href="#about" class="nav-link" data-section="04">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.about">About</span>
         </a>
-        <a href="#contact" class="nav-link" data-section="06">
+        <a href="#contact" class="nav-link" data-section="05">
           <span class="nav-prefix"></span>
           <span class="nav-text" data-i18n="nav.contact">Contact</span>
         </a>
@@ -342,7 +338,7 @@
       <div class="section-label">
         <span class="section-number">01</span>
         <span class="section-prompt">$</span>
-        <h2 class="section-title" data-glitch="/NOW" data-i18n="sections.now">/NOW</h2>
+        <h2 class="section-title" data-glitch="NOW" data-i18n="sections.now">NOW</h2>
       </div>
       <div class="section-divider">═══════════════════════════════════════════════════════</div>
     </div>
@@ -355,9 +351,7 @@
         </div>
         <div class="card-body">
           <p class="now-intro"><span class="code-comment-marker">/* </span><span data-i18n="now.intro">Section vivante. Mise à jour quand ça bouge.</span><span class="code-comment-marker"> */</span></p>
-          <ul class="now-list" id="now-list">
-            <li class="now-list-loading" data-i18n="ui.loadingNow">Chargement...</li>
-          </ul>
+          <p class="now-paragraph" id="now-paragraph"><span class="now-paragraph-loading" data-i18n="ui.loadingNow">Chargement...</span></p>
         </div>
       </div>
     </div>
@@ -410,7 +404,7 @@
   <section id="about" class="about">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">05</span>
+        <span class="section-number">04</span>
         <span class="section-prompt">$</span>
         <h2 class="section-title" data-glitch="ABOUT" data-i18n="sections.about">ABOUT</h2>
       </div>
@@ -440,9 +434,9 @@
             <!-- Populated from content.json -->
           </div>
 
-          <div class="tech-stack">
-            <p class="code-comment">/* Tech stack */</p>
-            <div class="tech-grid" id="tech-grid">
+          <div class="craft-stack">
+            <p class="code-comment">/* Stack */</p>
+            <div class="craft-block" id="craft-block">
               <!-- Populated from content.json -->
             </div>
           </div>
@@ -460,7 +454,7 @@
   <section id="timeline" class="git-timeline-section">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">04</span>
+        <span class="section-number">03</span>
         <span class="section-prompt">$</span>
         <h2 class="section-title" data-glitch="HISTORY" data-i18n="sections.history">HISTORY</h2>
       </div>
@@ -484,42 +478,11 @@
     </div>
   </section>
 
-  <!-- Writing Section (blog excerpts on home) -->
-  <section id="writing" class="blog writing">
-    <div class="section-header">
-      <div class="section-label">
-        <span class="section-number">03</span>
-        <span class="section-prompt">$</span>
-        <h2 class="section-title" data-glitch="WRITING" data-i18n="sections.writing">WRITING</h2>
-      </div>
-      <div class="section-divider">═══════════════════════════════════════════════════════</div>
-    </div>
-
-    <p class="writing-intro" data-i18n="writing.intro">Notes, posts, et ce que j'apprends en construisant.</p>
-
-    <div id="blog-grid" class="blog-grid">
-      <div class="blog-grid-loading">
-        <div class="skeleton-card"></div>
-        <div class="skeleton-card"></div>
-        <div class="skeleton-card"></div>
-      </div>
-    </div>
-
-    <div class="blog-footer">
-      <a href="/blog/" class="view-all-link">
-        <span class="link-bracket">[</span>
-        <span data-i18n="ui.viewAllArticles">VIEW ALL ARTICLES</span>
-        <span class="link-bracket">]</span>
-        <span class="link-arrow">→</span>
-      </a>
-    </div>
-  </section>
-
   <!-- Contact Section -->
   <section id="contact" class="contact">
     <div class="section-header">
       <div class="section-label">
-        <span class="section-number">06</span>
+        <span class="section-number">05</span>
         <span class="section-prompt">$</span>
         <h2 class="section-title" data-glitch="CONTACT" data-i18n="sections.contact">CONTACT</h2>
       </div>

--- a/frontend/js/core/card-renderer.js
+++ b/frontend/js/core/card-renderer.js
@@ -65,6 +65,9 @@ const CardRenderer = (() => {
         }
         if (!project.images?.length && !project.video) {
             card.classList.add('no-image');
+            // Surface the project type as a small badge so the card reads
+            // intentional, not broken (used by the .no-image::before badge)
+            if (project.type) card.dataset.cardType = project.type;
         }
 
         if (cfg.animationDelay) card.style.animationDelay = `${index * 0.1}s`;

--- a/frontend/js/core/content-loader.js
+++ b/frontend/js/core/content-loader.js
@@ -36,10 +36,27 @@ const ContentLoader = (() => {
                 .join('');
         }
 
-        // Tech stack
-        const tech = document.getElementById('tech-grid');
-        if (tech && siteContent.techStack) {
-            tech.innerHTML = siteContent.techStack.map(t => `<span class="tech-tag">${t}</span>`).join('');
+        // Craft block (replaces former tech stack tags)
+        const craft = document.getElementById('craft-block');
+        if (craft && siteContent.craft) {
+            craft.textContent = '';
+            const title = document.createElement('h4');
+            title.className = 'craft-title';
+            title.textContent = siteContent.craft.title || '';
+            const desc = document.createElement('p');
+            desc.className = 'craft-description';
+            desc.textContent = siteContent.craft.description || '';
+            craft.appendChild(title);
+            craft.appendChild(desc);
+        } else if (craft && siteContent.techStack) {
+            // Legacy fallback
+            craft.textContent = '';
+            siteContent.techStack.forEach(t => {
+                const span = document.createElement('span');
+                span.className = 'tech-tag';
+                span.textContent = t;
+                craft.appendChild(span);
+            });
         }
 
         // Social links
@@ -92,6 +109,28 @@ const ContentLoader = (() => {
         const dateEl = document.getElementById('now-date');
         if (dateEl && nowData.date) dateEl.textContent = nowData.date;
 
+        // New format: connected paragraph built from typed segments (text | link).
+        // Built with safe DOM APIs (no innerHTML) — no XSS risk.
+        const paragraphHost = document.getElementById('now-paragraph');
+        if (paragraphHost && Array.isArray(nowData.paragraph)) {
+            paragraphHost.textContent = '';
+            nowData.paragraph.forEach(seg => {
+                if (seg && typeof seg.text === 'string') {
+                    paragraphHost.appendChild(document.createTextNode(seg.text));
+                } else if (seg && seg.link && seg.link.url && seg.link.text) {
+                    const a = document.createElement('a');
+                    a.className = 'now-inline-link';
+                    a.href = seg.link.url;
+                    a.target = '_blank';
+                    a.rel = 'noopener noreferrer';
+                    a.textContent = seg.link.text;
+                    paragraphHost.appendChild(a);
+                }
+            });
+            return;
+        }
+
+        // Legacy format: list of items (kept for safety if data hasn't migrated)
         const list = document.getElementById('now-list');
         if (!list || !Array.isArray(nowData.items)) return;
 

--- a/frontend/js/git-timeline.js
+++ b/frontend/js/git-timeline.js
@@ -62,8 +62,9 @@ const GitTimeline = (() => {
         const totalPadding = CONFIG.padding.left + CONFIG.padding.right;
         const yearWidth = (availableWidth - totalPadding) / yearCount;
 
-        // Minimum 60px per year for readability
-        return Math.max(yearWidth, 60);
+        // Minimum 48px per year — keeps timeline fitting in narrower viewports
+        // before the horizontal scrollbar kicks in
+        return Math.max(yearWidth, 48);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -349,9 +350,25 @@ const GitTimeline = (() => {
             const ongoing = isOngoing(branch);
 
             branch.commits.forEach((commit, idx) => {
-                // Position commits along the branch
-                // First commit near start, subsequent commits spaced along
-                const commitX = branch._startX + CONFIG.curveRadius + 10 + (idx * 120);
+                // Position commits along the branch:
+                // - idx 0 sits near the branch start
+                // - subsequent commits use their own date if available,
+                //   otherwise fall back to a fixed horizontal stride (220px)
+                let commitX;
+                if (idx === 0) {
+                    commitX = branch._startX + CONFIG.curveRadius + 10;
+                } else {
+                    const commitDate = parseDate(commit.date);
+                    if (commitDate != null) {
+                        commitX = yearToX(commitDate);
+                    } else {
+                        commitX = branch._startX + CONFIG.curveRadius + 10 + (idx * 220);
+                    }
+                }
+
+                // Alternate vertical offset for siblings on the same branch so
+                // long titles don't visually collide on a single line.
+                const verticalStagger = idx === 0 ? -14 : 22;
 
                 const marker = document.createElement('div');
                 marker.className = `git-commit-marker git-commit-${branch.type} ${ongoing ? 'ongoing' : ''}`;
@@ -359,7 +376,7 @@ const GitTimeline = (() => {
                 //Do not show hash for the first one
                 //marker.dataset.commitHash = commit.hash;
                 marker.style.left = `${commitX}px`;
-                marker.style.top = `${laneY - 14}px`;
+                marker.style.top = `${laneY + verticalStagger}px`;
                 marker.style.setProperty('--branch-color', color);
 
                 // Format date range

--- a/frontend/themes/blueprint/blueprint.css
+++ b/frontend/themes/blueprint/blueprint.css
@@ -356,6 +356,16 @@ body[data-theme="blueprint"] .hero-subtitle {
   animation-delay: 1.5s;
 }
 
+/* Paragraph form: tighter letter-spacing, slightly bigger size for body readability */
+body[data-theme="blueprint"] .hero-subtitle.hero-quote {
+  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  letter-spacing: 0.02em;
+  max-width: 640px;
+  margin: var(--spacing-md) auto var(--spacing-lg);
+  text-align: left;
+  line-height: 1.75;
+}
+
 body[data-theme="blueprint"] .annotation-mark {
   color: var(--accent-redline);
 }

--- a/frontend/themes/default/default.css
+++ b/frontend/themes/default/default.css
@@ -174,32 +174,63 @@ body[data-theme="default"] .hero-title {
   margin-bottom: var(--spacing-md);
 }
 
+body[data-theme="default"] .hero-title {
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: left;
+  padding-left: 1.5rem;
+}
+
 body[data-theme="default"] .hero-title .title-line {
   display: block;
-  font-size: clamp(2.75rem, 9vw, 5rem);
-  font-weight: 650;
-  line-height: 1.05;
-  letter-spacing: -0.035em;
-  color: var(--text-primary);
+  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  opacity: 0.75;
 }
 
 body[data-theme="default"] .hero-title .title-line:last-child {
   color: var(--accent);
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-soft) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background: none;
+  -webkit-text-fill-color: var(--accent);
+  opacity: 0.9;
 }
 
 body[data-theme="default"] .hero-subtitle {
-  font-size: clamp(1.0625rem, 2.5vw, 1.25rem);
-  color: var(--text-secondary);
+  font-size: clamp(1.125rem, 2.2vw, 1.4rem);
+  color: var(--text-primary);
   font-weight: 400;
-  line-height: 1.7;
-  max-width: 640px;
+  line-height: 1.6;
+  max-width: 620px;
   margin: 0 auto var(--spacing-lg);
   letter-spacing: -0.01em;
   text-align: left;
+  font-style: italic;
+}
+
+/* Citation feel: decorative open-quote glyph + tighter italic body */
+body[data-theme="default"] .hero-quote-paragraph {
+  position: relative;
+  padding-left: 1.5rem;
+  border-left: 2px solid var(--accent);
+}
+
+body[data-theme="default"] .hero-quote-paragraph::before {
+  content: "“";
+  position: absolute;
+  left: 0.4rem;
+  top: -1.5rem;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 4rem;
+  line-height: 1;
+  color: var(--accent);
+  opacity: 0.35;
+  font-style: normal;
+  pointer-events: none;
 }
 
 body[data-theme="default"] .hero-subtitle .annotation-mark {

--- a/frontend/themes/default/default.css
+++ b/frontend/themes/default/default.css
@@ -195,10 +195,11 @@ body[data-theme="default"] .hero-subtitle {
   font-size: clamp(1.0625rem, 2.5vw, 1.25rem);
   color: var(--text-secondary);
   font-weight: 400;
-  line-height: 1.65;
-  max-width: 480px;
+  line-height: 1.7;
+  max-width: 640px;
   margin: 0 auto var(--spacing-lg);
   letter-spacing: -0.01em;
+  text-align: left;
 }
 
 body[data-theme="default"] .hero-subtitle .annotation-mark {

--- a/frontend/themes/retro90s/retro90s.css
+++ b/frontend/themes/retro90s/retro90s.css
@@ -439,6 +439,16 @@ body[data-theme="retro90s"] .hero-subtitle {
   animation: subtitle-wobble 3s ease-in-out infinite;
 }
 
+/* Paragraph form: kill the wobble (unreadable on long text), keep playful body font */
+body[data-theme="retro90s"] .hero-subtitle.hero-quote {
+  animation: none;
+  font-size: clamp(0.95rem, 1.6vw, 1.15rem);
+  max-width: 640px;
+  margin: var(--spacing-sm) auto var(--spacing-md);
+  text-align: left;
+  line-height: 1.7;
+}
+
 @keyframes subtitle-wobble {
   0%, 100% { transform: rotate(-1deg); }
   50% { transform: rotate(1deg); }

--- a/frontend/themes/terminal/terminal.css
+++ b/frontend/themes/terminal/terminal.css
@@ -405,6 +405,22 @@ body[data-theme="terminal"] .hero-subtitle {
   text-shadow: var(--glow-primary);
 }
 
+/* Paragraph form (post-repositioning hero copy): readable size, mono, left-aligned */
+body[data-theme="terminal"] .hero-subtitle.hero-quote {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: clamp(0.9rem, 1.4vw, 1.05rem);
+  letter-spacing: 0.02em;
+  text-shadow: none;
+  max-width: 640px;
+  margin: var(--spacing-md) auto var(--spacing-lg);
+  text-align: left;
+  line-height: 1.75;
+}
+
+body[data-theme="terminal"] .hero-quote-paragraph {
+  color: var(--primary);
+}
+
 body[data-theme="terminal"] .hero-subtitle .annotation-mark::before {
   content: '>';
   animation: blink-fast 0.5s step-end infinite;


### PR DESCRIPTION
## Summary

The repositioning structure (Now · Work · Writing · History · About · Contact) is solid, but the copy from the cloud agent was flat, marketeux, and heavy on repetition. This pass dedupes the layers and assigns one job per section.

**Repetitions killed:**
- "Lead Front-End @ CBA · AgatheYOU · side projects" appeared **3x** (Hero implicit, /now Build, Work Product Builder subtitle)
- "Platform Architect @ CBA · IA agentique" appeared **4x** (Hero, /now Transform, Work card, About detail)
- "product builder" / "transformer" appeared **6+ times**

**Section roles, now respected:**
| Section | Job | Was | Is now |
|---|---|---|---|
| Hero | WHY | "Je suis product builder. Mais à force de…" (5-line poem) | One paragraph, left-aligned, 640px, blog-intro feel |
| /now | WHAT this month | Mirrored work cards | Op status, dated, deduped |
| Work subtitles | Category description | Listed Tom's titles | Describes the territory itself |
| About | HOW | Re-listed missions | Craft preferences and opinions |

## Changes

- **Hero layout**: `.hero-quote` now `text-align: left`, `max-width: 640px`, single `<p>` instead of 5 forced line breaks. Per-theme overrides in default/terminal/blueprint/retro90s so the long-form copy stays readable in each style.
- **i18n locales** (`fr.json`, `en.json`): added `hero.{title,quote}` and `about.{intro,detail}` (previously missing — EN was falling back to the FR-hardcoded HTML), refined `work.*.subtitle`, kept `writing.intro`.
- **Content data** (`data/{fr,en}/content.json`): `hero.quote` array → string; `about` rewritten; specs `focus`/`status` deduped; meta description tightened.
- **/now** (`data/{fr,en}/now.json`): items reworded around current operational state, em-dashes killed.

## Test plan

- [x] Default theme — FR + EN
- [x] Terminal theme — FR
- [x] Blueprint theme — FR
- [x] Retro90s theme — FR (wobble disabled on paragraph form)
- [x] No console errors related to copy/i18n (only blog API unavailable in local dev)
- [ ] Visual review on staging once deployed