### PR TITLE
feat(timeline): compact markers, auto-scroll right, AgatheYou casing

### DIFF
--- a/.claude/work/2026-04-25-180000-timeline-polish.md
+++ b/.claude/work/2026-04-25-180000-timeline-polish.md
@@ -1,0 +1,40 @@
+# Timeline Polish — Compactness, Auto-Scroll Right, AgatheYou Fix
+
+**Status**: in_progress
+**Branch**: `feature/timeline-polish`
+**Started**: 2026-04-25 18:00
+
+## Task
+Tom feedback sur la timeline /history :
+1. Trop large à mesure que la vie remplit. Auto-scroll à droite par défaut, vieux trucs cachés à gauche.
+2. Side projects (Skoolbook, Teach Tools, Studio Manifeste, Ride My Park) : afficher juste le nom du projet, pas "Fondateur - Skoolbook". Une seule ligne, plus compact.
+3. CBA prend trop de largeur, "Platform Architect" passe sous "Lead Dev Lead Front-End" → moche. Trouver design plus joli en gardant les vraies dates.
+4. Typo : `AgatheYOU` → `AgatheYou`.
+
+## Files Being Modified
+- `frontend/data/fr/git-history.json` — typo AgatheYou + ajout markerLabel court
+- `frontend/data/en/git-history.json` — typo AgatheYou + ajout markerLabel court
+- `frontend/js/git-timeline.js` — display logic, auto-scroll right, fixed yearWidth
+- `frontend/css/timeline.css` — max-width sur marker-title
+
+## Strategy
+- Ajouter un champ optionnel `markerLabel` dans `commit.details` pour afficher une version courte sur la timeline (le titre complet reste dans l'overlay détail).
+- Pour les projets : marker = juste `branch.name` (Skoolbook, Teach Tools, etc.), titre complet en overlay.
+- Pour CBA : `markerLabel = "Lead Front-End AgatheYou"` et `markerLabel = "Platform Architect"` — même lane, dates respectives, pas de stagger vertical artificiel.
+- `calculateYearWidth` : passer le min de 48px à 130px (cohérent avec le défaut). Si overflow → scroll horizontal naturel.
+- Après render : `scrollContainer.scrollLeft = scrollContainer.scrollWidth` pour démarrer à droite.
+- CSS : `max-width: 240px` + `text-overflow: ellipsis` sur `.marker-title` pour empêcher les pavés.
+
+## Progress
+- [x] Work file créé
+- [ ] Data : AgatheYou + markerLabel
+- [ ] JS renderCommitCards refactor
+- [ ] JS calculateYearWidth + auto-scroll
+- [ ] CSS marker-title max-width
+- [ ] Test visuel 4 thèmes
+- [ ] Commit + push + merge
+
+## Notes/Discoveries
+- `verticalStagger` actuel (-14 / +22) crée le problème CBA : le 2e marker se retrouve sous la lane line, visuellement entre la branche CBA et le trunk.
+- `marker-title` a `text-overflow: ellipsis` mais pas de `max-width`, donc inactif (white-space: nowrap fait juste s'étendre).
+- Mobile timeline (`renderMobileTimeline`) a la même logique projet `${title} - ${company}` à mettre à jour aussi.

--- a/frontend/css/timeline.css
+++ b/frontend/css/timeline.css
@@ -299,6 +299,9 @@
     font-weight: 600;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 220px;
+    display: inline-block;
+    vertical-align: middle;
 }
 
 .marker-badge {

--- a/frontend/data/en/git-history.json
+++ b/frontend/data/en/git-history.json
@@ -151,7 +151,8 @@
           "message": "Joined CBA as Lead Developer",
           "author": "CBA Informatique Liberale",
           "details": {
-            "title": "Lead Developer · Lead Front-End AgatheYOU",
+            "title": "Lead Developer · Lead Front-End AgatheYou",
+            "markerLabel": "Lead Front-End AgatheYou",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Leading a team of 8 developers building web and mobile applications with Angular & Ionic. Architecting multiple applications and implementing CI/CD pipeline.",
@@ -165,6 +166,7 @@
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Platform Architect (Platform & Agentic AI)",
+            "markerLabel": "Platform Architect",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "6-month mission (Apr. 2026 → Sept. 2026) alongside the Lead Front-End role. Design and evolve a development and design platform, integrate agentic capabilities, support product and tech teams, spread a platform culture.",

--- a/frontend/data/en/git-history.json
+++ b/frontend/data/en/git-history.json
@@ -95,8 +95,8 @@
       ]
     },
     {
-      "id": "skoolbook",
-      "name": "Skoolbook",
+      "id": "side-projects-edu",
+      "name": "Side Projects",
       "type": "project",
       "startDate": "2023-01",
       "endDate": "ongoing",
@@ -108,21 +108,13 @@
           "author": "Skoolbook",
           "details": {
             "title": "Founder",
+            "markerLabel": "Skoolbook",
             "company": "Skoolbook",
             "location": "skoolbook.fr",
             "description": "School library management platform built to help teachers track book loans and encourage reading. Intuitive interface for teachers with student autonomy features.",
             "tags": ["WordPress", "PHP", "UX/UI", "Education"]
           }
-        }
-      ]
-    },
-    {
-      "id": "teachtools",
-      "name": "Teach Tools",
-      "type": "project",
-      "startDate": "2023-06",
-      "endDate": "ongoing",
-      "commits": [
+        },
         {
           "hash": "tt2023",
           "date": "2023-06",
@@ -130,6 +122,7 @@
           "author": "Teach Tools",
           "details": {
             "title": "Founder",
+            "markerLabel": "Teach Tools",
             "company": "Teach Tools",
             "location": "teach-tools.com",
             "description": "AI-powered pedagogical assistant generating exercises and images for teachers. Next.js application with AI integration and CI/CD pipeline.",
@@ -152,7 +145,7 @@
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Lead Developer · Lead Front-End AgatheYou",
-            "markerLabel": "Lead Front-End AgatheYou",
+            "markerLabel": "Lead Front-End",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Leading a team of 8 developers building web and mobile applications with Angular & Ionic. Architecting multiple applications and implementing CI/CD pipeline.",
@@ -166,7 +159,7 @@
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Platform Architect (Platform & Agentic AI)",
-            "markerLabel": "Platform Architect",
+            "markerLabel": "AI Platform Architect",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "6-month mission (Apr. 2026 → Sept. 2026) alongside the Lead Front-End role. Design and evolve a development and design platform, integrate agentic capabilities, support product and tech teams, spread a platform culture.",

--- a/frontend/data/en/git-history.json
+++ b/frontend/data/en/git-history.json
@@ -162,6 +162,7 @@
             "markerLabel": "AI Platform Architect",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
+            "dateRange": "Apr 2026 → Sept 2026",
             "description": "6-month mission (Apr. 2026 → Sept. 2026) alongside the Lead Front-End role. Design and evolve a development and design platform, integrate agentic capabilities, support product and tech teams, spread a platform culture.",
             "tags": ["Agentic AI", "Platform Engineering", "Developer Experience", "Product Experience"]
           }

--- a/frontend/data/en/now.json
+++ b/frontend/data/en/now.json
@@ -1,9 +1,9 @@
 {
   "date": "April 2026",
   "headerLabel": "WHERE I'M AT",
-  "intro": "Living section. Updated when things move.",
+  "intro": "",
   "paragraph": [
-    { "text": "Last month I took on a 6-month mission on top of the Lead Front-End role: Platform Architect at CBA, working on the dev platform and agentic AI for product and tech teams. AgatheYOU keeps shipping. " },
+    { "text": "Last month I took on a 6-month mission on top of the Lead Front-End role: Platform Architect at CBA, working on the dev platform and agentic AI for product and tech teams. AgatheYou keeps shipping. " },
     { "link": { "text": "Studio Manifeste", "url": "https://studio.alphaluppi.fr" } },
     { "text": ", the AI agency I'm co-founding, is taking shape on the side. Two side projects in the oven, no freelance window this quarter." }
   ]

--- a/frontend/data/fr/git-history.json
+++ b/frontend/data/fr/git-history.json
@@ -95,8 +95,8 @@
       ]
     },
     {
-      "id": "skoolbook",
-      "name": "Skoolbook",
+      "id": "side-projects-edu",
+      "name": "Side Projects",
       "type": "project",
       "startDate": "2023-01",
       "endDate": "ongoing",
@@ -108,21 +108,13 @@
           "author": "Skoolbook",
           "details": {
             "title": "Fondateur",
+            "markerLabel": "Skoolbook",
             "company": "Skoolbook",
             "location": "skoolbook.fr",
             "description": "Plateforme de gestion de bibliothèque scolaire pour aider les enseignants à suivre les emprunts et encourager la lecture. Interface intuitive avec fonctionnalités d'autonomie élève.",
             "tags": ["WordPress", "PHP", "UX/UI", "Education"]
           }
-        }
-      ]
-    },
-    {
-      "id": "teachtools",
-      "name": "Teach Tools",
-      "type": "project",
-      "startDate": "2023-06",
-      "endDate": "ongoing",
-      "commits": [
+        },
         {
           "hash": "tt2023",
           "date": "2023-06",
@@ -130,6 +122,7 @@
           "author": "Teach Tools",
           "details": {
             "title": "Fondateur",
+            "markerLabel": "Teach Tools",
             "company": "Teach Tools",
             "location": "teach-tools.com",
             "description": "Assistant pédagogique propulsé par l'IA générant exercices et images pour enseignants. Application Next.js avec intégration IA et pipeline CI/CD.",
@@ -152,7 +145,7 @@
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Lead Developer · Lead Front-End AgatheYou",
-            "markerLabel": "Lead Front-End AgatheYou",
+            "markerLabel": "Lead Front-End",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Lead d'une équipe de 8 développeurs construisant applications web et mobiles avec Angular & Ionic. Architecture multi-applications et mise en place pipeline CI/CD.",
@@ -166,7 +159,7 @@
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Platform Architect (Plateforme & IA Agentique)",
-            "markerLabel": "Platform Architect",
+            "markerLabel": "AI Platform Architect",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Mission de 6 mois (avr. 2026 → sept. 2026) en parallèle du Lead Front-End. Concevoir et faire évoluer une plateforme de développement et de conception, intégrer des capacités agentiques, accompagner les équipes produit et techniques, diffuser une culture plateforme.",

--- a/frontend/data/fr/git-history.json
+++ b/frontend/data/fr/git-history.json
@@ -162,6 +162,7 @@
             "markerLabel": "AI Platform Architect",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
+            "dateRange": "Avr 2026 → Sept 2026",
             "description": "Mission de 6 mois (avr. 2026 → sept. 2026) en parallèle du Lead Front-End. Concevoir et faire évoluer une plateforme de développement et de conception, intégrer des capacités agentiques, accompagner les équipes produit et techniques, diffuser une culture plateforme.",
             "tags": ["IA Agentique", "Platform Engineering", "Developer Experience", "Product Experience"]
           }

--- a/frontend/data/fr/git-history.json
+++ b/frontend/data/fr/git-history.json
@@ -151,7 +151,8 @@
           "message": "Arrivée chez CBA en tant que Lead Dev",
           "author": "CBA Informatique Liberale",
           "details": {
-            "title": "Lead Developer · Lead Front-End AgatheYOU",
+            "title": "Lead Developer · Lead Front-End AgatheYou",
+            "markerLabel": "Lead Front-End AgatheYou",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Lead d'une équipe de 8 développeurs construisant applications web et mobiles avec Angular & Ionic. Architecture multi-applications et mise en place pipeline CI/CD.",
@@ -165,6 +166,7 @@
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Platform Architect (Plateforme & IA Agentique)",
+            "markerLabel": "Platform Architect",
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "description": "Mission de 6 mois (avr. 2026 → sept. 2026) en parallèle du Lead Front-End. Concevoir et faire évoluer une plateforme de développement et de conception, intégrer des capacités agentiques, accompagner les équipes produit et techniques, diffuser une culture plateforme.",

--- a/frontend/data/fr/now.json
+++ b/frontend/data/fr/now.json
@@ -1,9 +1,9 @@
 {
   "date": "avril 2026",
   "headerLabel": "OÙ J'EN SUIS",
-  "intro": "Section vivante. Mise à jour quand ça bouge.",
+  "intro": "",
   "paragraph": [
-    { "text": "Le mois dernier j'ai pris une mission de 6 mois en plus du Lead Front-End : Platform Architect chez CBA, sur la plateforme dev et l'IA agentique pour les équipes produit et tech. AgatheYOU continue d'évoluer en prod. " },
+    { "text": "Le mois dernier j'ai pris une mission de 6 mois en plus du Lead Front-End : Platform Architect chez CBA, sur la plateforme dev et l'IA agentique pour les équipes produit et tech. AgatheYou continue d'évoluer en prod. " },
     { "link": { "text": "Studio Manifeste", "url": "https://studio.alphaluppi.fr" } },
     { "text": ", l'agence IA qu'on co-fonde, prend forme en parallèle. Deux side projects sur le feu, pas de fenêtre freelance ce trimestre." }
   ]

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -6,6 +6,7 @@
   },
   "hero": {
     "title": "HEY",
+    "signature": "Tom",
     "quote": "I've been coding for 8 years. My job is building products. AI didn't change that craft, it changed who can do it and how fast. From building with it, I ended up helping other teams fold it into their day-to-day work. Same craft, two angles."
   },
   "about": {

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -7,7 +7,7 @@
   "hero": {
     "title": "HEY",
     "signature": "Tom",
-    "quote": "I've been coding for 8 years. My job is building products. AI didn't change that craft, it changed who can do it and how fast. From building with it, I ended up helping other teams fold it into their day-to-day work. Same craft, two angles."
+    "quote": "I've been coding for 8 years. My job is building products. AI didn't change that craft, it changed who can do it and how fast. From building with it, I ended up helping other teams fold it into their day-to-day work."
   },
   "about": {
     "intro": "I think you learn a craft <highlight>by doing it</highlight>, and you learn to transform a craft <highlight>by having done it</highlight>.",
@@ -100,7 +100,7 @@
   },
   "now": {
     "headerLabel": "WHERE I'M AT",
-    "intro": "Living section. Updated when things move."
+    "intro": ""
   },
   "work": {
     "productBuilder": {

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -6,6 +6,7 @@
   },
   "hero": {
     "title": "SALUT",
+    "signature": "Tom",
     "quote": "Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien. Même métier, deux angles."
   },
   "about": {

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -7,7 +7,7 @@
   "hero": {
     "title": "SALUT",
     "signature": "Tom",
-    "quote": "Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien. Même métier, deux angles."
+    "quote": "Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien."
   },
   "about": {
     "intro": "Je crois qu'on apprend un métier <highlight>en le faisant</highlight>, et qu'on apprend à le transformer <highlight>en l'ayant fait</highlight>.",
@@ -100,7 +100,7 @@
   },
   "now": {
     "headerLabel": "OÙ J'EN SUIS",
-    "intro": "Section vivante. Mise à jour quand ça bouge."
+    "intro": ""
   },
   "work": {
     "productBuilder": {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -273,6 +273,7 @@
         <span class="annotation-mark hero-quote-mark-open"></span>
         <p class="hero-quote-paragraph" data-i18n="hero.quote">Je code depuis 8 ans. Mon métier, c'est de construire des produits. L'IA n'a pas changé ce métier, elle a changé qui peut le faire et à quelle vitesse. À force de construire avec elle, j'ai commencé à aider d'autres équipes à l'intégrer dans leur quotidien. Même métier, deux angles.</p>
         <span class="annotation-mark hero-quote-mark-close"></span>
+        <p class="hero-signature">— <span data-i18n="hero.signature">Tom</span></p>
       </div>
 
       <!-- 90s Under Construction Badge -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -351,7 +351,6 @@
           <span class="now-date" id="now-date" data-content="now.date">avril 2026</span>
         </div>
         <div class="card-body">
-          <p class="now-intro"><span class="code-comment-marker">/* </span><span data-i18n="now.intro">Section vivante. Mise à jour quand ça bouge.</span><span class="code-comment-marker"> */</span></p>
           <p class="now-paragraph" id="now-paragraph"><span class="now-paragraph-loading" data-i18n="ui.loadingNow">Chargement...</span></p>
         </div>
       </div>

--- a/frontend/js/git-timeline.js
+++ b/frontend/js/git-timeline.js
@@ -62,9 +62,10 @@ const GitTimeline = (() => {
         const totalPadding = CONFIG.padding.left + CONFIG.padding.right;
         const yearWidth = (availableWidth - totalPadding) / yearCount;
 
-        // Minimum 48px per year — keeps timeline fitting in narrower viewports
-        // before the horizontal scrollbar kicks in
-        return Math.max(yearWidth, 48);
+        // Minimum 140px per year — keeps each year readable.
+        // When the timeline grows past the viewport, we let it overflow and
+        // auto-scroll the user to the right (latest events) on init/render.
+        return Math.max(yearWidth, 140);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -366,9 +367,11 @@ const GitTimeline = (() => {
                     }
                 }
 
-                // Alternate vertical offset for siblings on the same branch so
-                // long titles don't visually collide on a single line.
-                const verticalStagger = idx === 0 ? -14 : 22;
+                // All markers sit just above the branch line for visual
+                // consistency. The compact label (markerLabel) keeps things
+                // single-line so multiple commits on the same branch (e.g. CBA)
+                // can sit on the same horizontal axis without colliding.
+                const verticalStagger = -14;
 
                 const marker = document.createElement('div');
                 marker.className = `git-commit-marker git-commit-${branch.type} ${ongoing ? 'ongoing' : ''}`;
@@ -384,14 +387,15 @@ const GitTimeline = (() => {
                 const endYear = ongoing ? 'Present' : branch.endDate.split('-')[0];
                 const dateRange = `${startYear} - ${endYear}`;
 
-                // Compact marker: format depends on branch type
-                // For projects: "Role - Project Name" (e.g., "Fondateur - Skoolbook")
-                // For work/education: just the title
+                // Compact marker label:
+                // - Projects: just the project name (branch.name) — e.g. "Skoolbook"
+                // - Work/education: details.markerLabel if present, else details.title
+                // The full title always shows in the hover overlay for context.
                 let displayTitle;
                 if (branch.type === 'project') {
-                    displayTitle = `${commit.details.title} - ${commit.details.company}`;
+                    displayTitle = branch.name;
                 } else {
-                    displayTitle = commit.details.title;
+                    displayTitle = commit.details.markerLabel || commit.details.title;
                 }
 
                 marker.innerHTML = `
@@ -671,12 +675,12 @@ const GitTimeline = (() => {
                 const endYear = ongoing ? 'Present' : branch.endDate.split('-')[0];
                 const dateRange = `${startYear} - ${endYear}`;
 
-                // Format title based on type
+                // Format title based on type (mirror desktop logic)
                 let displayTitle;
                 if (branch.type === 'project') {
-                    displayTitle = `${commit.details.title} - ${commit.details.company}`;
+                    displayTitle = branch.name;
                 } else {
-                    displayTitle = commit.details.title;
+                    displayTitle = commit.details.markerLabel || commit.details.title;
                 }
 
                 const commitEl = document.createElement('div');
@@ -751,8 +755,10 @@ const GitTimeline = (() => {
         // Render SVG graph first to get dimensions and trunkY
         const { totalWidth, totalHeight, trunkY } = renderSvg(lanesContainer, branches, laneCount);
 
-        // Set container height (width is handled by CSS width: 100%)
+        // Set container size. Width must be explicit so absolute markers
+        // beyond the viewport contribute to scrollWidth (auto-scroll right).
         lanesContainer.style.height = `${totalHeight}px`;
+        lanesContainer.style.width = `${totalWidth}px`;
 
         // Render commit cards (with trunkY for positioning)
         renderCommitCards(lanesContainer, branches, totalWidth, trunkY);
@@ -772,6 +778,15 @@ const GitTimeline = (() => {
         // Create overlay and setup events (desktop only)
         createOverlay();
         setupEvents();
+
+        // Auto-scroll horizontally to the right so the latest events are
+        // visible by default. Older events stay accessible by scrolling left.
+        // Wait one frame for layout to settle before reading scrollWidth.
+        requestAnimationFrame(() => {
+            if (scrollContainer) {
+                scrollContainer.scrollLeft = scrollContainer.scrollWidth;
+            }
+        });
 
         console.log('%c[GitTimeline] Rendered', 'color: #33ff00');
     }

--- a/frontend/js/git-timeline.js
+++ b/frontend/js/git-timeline.js
@@ -62,13 +62,13 @@ const GitTimeline = (() => {
         const totalPadding = CONFIG.padding.left + CONFIG.padding.right;
         const yearWidth = (availableWidth - totalPadding) / yearCount;
 
-        // Soft floor: 100px per year. At default 100% zoom on a normal desktop
-        // the natural fit value (>100) wins, so the timeline fits the viewport
-        // exactly with no horizontal scrollbar. When a user zooms in (CSS
-        // viewport shrinks), the floor kicks in, content overflows, and
-        // render() auto-scrolls to the right — latest events stay visible,
-        // older ones remain accessible by scrolling left.
-        return Math.max(yearWidth, 100);
+        // Pure fit-to-viewport, no minimum floor: the timeline always
+        // tiles the available width exactly, so it never overflows and
+        // never shows a horizontal scrollbar — at any zoom level. The
+        // trade-off is that very small viewports may compress markers,
+        // but on desktop (>=1025px, where the horizontal timeline shows)
+        // the natural fit stays comfortable.
+        return Math.max(yearWidth, 30);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -435,9 +435,13 @@ const GitTimeline = (() => {
                 // If its natural left edge sits inside the previous sibling's
                 // bounding box, nudge it right just enough to clear (no
                 // vertical stacking — Tom prefers single-line lanes).
+                // The shift is capped at totalWidth - markerWidth so a
+                // marker never extends past the timeline's right edge,
+                // which would create a horizontal scrollbar.
                 const markerWidth = marker.offsetWidth;
+                const maxAllowedX = Math.max(0, totalWidth - markerWidth);
                 if (commitX < prevMarkerRight + MARKER_GAP) {
-                    commitX = prevMarkerRight + MARKER_GAP;
+                    commitX = Math.min(prevMarkerRight + MARKER_GAP, maxAllowedX);
                     marker.style.left = `${commitX}px`;
                 }
                 prevMarkerRight = commitX + markerWidth;

--- a/frontend/js/git-timeline.js
+++ b/frontend/js/git-timeline.js
@@ -62,10 +62,13 @@ const GitTimeline = (() => {
         const totalPadding = CONFIG.padding.left + CONFIG.padding.right;
         const yearWidth = (availableWidth - totalPadding) / yearCount;
 
-        // Minimum 140px per year — keeps each year readable.
-        // When the timeline grows past the viewport, we let it overflow and
-        // auto-scroll the user to the right (latest events) on init/render.
-        return Math.max(yearWidth, 140);
+        // Soft floor: 100px per year. At default 100% zoom on a normal desktop
+        // the natural fit value (>100) wins, so the timeline fits the viewport
+        // exactly with no horizontal scrollbar. When a user zooms in (CSS
+        // viewport shrinks), the floor kicks in, content overflows, and
+        // render() auto-scrolls to the right — latest events stay visible,
+        // older ones remain accessible by scrolling left.
+        return Math.max(yearWidth, 100);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -344,13 +347,7 @@ const GitTimeline = (() => {
      * Branches are now ABOVE the trunk
      */
     function renderCommitCards(container, branches, totalWidth, trunkY) {
-        // Threshold (px) below which two adjacent commits on the same branch
-        // are considered "horizontally close" and need a vertical stagger to
-        // avoid overlapping. Anything wider than this stays on a single line.
-        const STAGGER_THRESHOLD = 180;
-
-        // Pre-compute commit X positions per branch so we can detect
-        // horizontal collisions before deciding the vertical stagger.
+        // Natural X position of a commit (its true date on the timeline).
         function commitXFor(branch, commit, idx) {
             if (idx === 0) return branch._startX + CONFIG.curveRadius + 10;
             const commitDate = parseDate(commit.date);
@@ -358,43 +355,49 @@ const GitTimeline = (() => {
             return branch._startX + CONFIG.curveRadius + 10 + (idx * 220);
         }
 
+        // Minimum horizontal gap between adjacent markers on the same branch
+        // (in px). When two commits would visually collide at their natural
+        // dates, the later one is nudged right just enough to clear the prev.
+        const MARKER_GAP = 8;
+
         branches.forEach(branch => {
             // laneY is above the trunk (smaller Y value)
             const laneY = trunkY - (branch._lane + 1) * CONFIG.laneHeight;
             const color = CONFIG.colors[branch.type] || CONFIG.colors.work;
             const ongoing = isOngoing(branch);
 
-            branch.commits.forEach((commit, idx) => {
-                const commitX = commitXFor(branch, commit, idx);
+            // Tracks the right edge of the previously rendered marker on this
+            // branch — used to shift the next one rightwards when its natural
+            // date would put it under the previous label.
+            let prevMarkerRight = -Infinity;
 
-                // Vertical stagger:
-                // - Single commit OR first commit of a multi-commit branch:
-                //   sit centered on the branch line (-14).
-                // - Subsequent commits: stay on the line if the previous
-                //   commit is far enough horizontally; otherwise alternate
-                //   above/below to avoid overlap (+22 = below the line).
-                let verticalStagger = -14;
-                if (idx > 0) {
-                    const prevX = commitXFor(branch, branch.commits[idx - 1], idx - 1);
-                    const gap = commitX - prevX;
-                    if (gap < STAGGER_THRESHOLD) {
-                        verticalStagger = (idx % 2 === 1) ? 22 : -14;
-                    }
-                }
+            branch.commits.forEach((commit, idx) => {
+                let commitX = commitXFor(branch, commit, idx);
 
                 const marker = document.createElement('div');
                 marker.className = `git-commit-marker git-commit-${branch.type} ${ongoing ? 'ongoing' : ''}`;
                 marker.dataset.branchId = branch.id;
                 //Do not show hash for the first one
                 //marker.dataset.commitHash = commit.hash;
+                // All markers sit centered on the branch line — keeping them
+                // on a single horizontal line. If two commits are too close
+                // horizontally, the second one shifts right (see below) so
+                // they sit side-by-side instead of stacking vertically.
                 marker.style.left = `${commitX}px`;
-                marker.style.top = `${laneY + verticalStagger}px`;
+                marker.style.top = `${laneY - 14}px`;
                 marker.style.setProperty('--branch-color', color);
 
-                // Format date range
-                const startYear = branch.startDate.split('-')[0];
-                const endYear = ongoing ? 'Present' : branch.endDate.split('-')[0];
-                const dateRange = `${startYear} - ${endYear}`;
+                // Format date range — commit-level override (commit.details.dateRange)
+                // wins, so a sub-mission with bounded dates (e.g. "Apr 2026 → Sept 2026")
+                // can override its parent branch's open-ended "2024 - Present".
+                let dateRange;
+                if (commit.details.dateRange) {
+                    dateRange = commit.details.dateRange;
+                } else {
+                    const startYear = branch.startDate.split('-')[0];
+                    const endYear = ongoing ? 'Present' : branch.endDate.split('-')[0];
+                    dateRange = `${startYear} - ${endYear}`;
+                }
 
                 // Compact marker label, in priority order:
                 // 1. commit.details.markerLabel (per-commit override, e.g. "Skoolbook")
@@ -427,6 +430,17 @@ const GitTimeline = (() => {
                 //marker.dataset.hash = commit.hash;
 
                 container.appendChild(marker);
+
+                // After the marker is in the DOM we know its real width.
+                // If its natural left edge sits inside the previous sibling's
+                // bounding box, nudge it right just enough to clear (no
+                // vertical stacking — Tom prefers single-line lanes).
+                const markerWidth = marker.offsetWidth;
+                if (commitX < prevMarkerRight + MARKER_GAP) {
+                    commitX = prevMarkerRight + MARKER_GAP;
+                    marker.style.left = `${commitX}px`;
+                }
+                prevMarkerRight = commitX + markerWidth;
             });
         });
     }

--- a/frontend/js/git-timeline.js
+++ b/frontend/js/git-timeline.js
@@ -344,6 +344,20 @@ const GitTimeline = (() => {
      * Branches are now ABOVE the trunk
      */
     function renderCommitCards(container, branches, totalWidth, trunkY) {
+        // Threshold (px) below which two adjacent commits on the same branch
+        // are considered "horizontally close" and need a vertical stagger to
+        // avoid overlapping. Anything wider than this stays on a single line.
+        const STAGGER_THRESHOLD = 180;
+
+        // Pre-compute commit X positions per branch so we can detect
+        // horizontal collisions before deciding the vertical stagger.
+        function commitXFor(branch, commit, idx) {
+            if (idx === 0) return branch._startX + CONFIG.curveRadius + 10;
+            const commitDate = parseDate(commit.date);
+            if (commitDate != null) return yearToX(commitDate);
+            return branch._startX + CONFIG.curveRadius + 10 + (idx * 220);
+        }
+
         branches.forEach(branch => {
             // laneY is above the trunk (smaller Y value)
             const laneY = trunkY - (branch._lane + 1) * CONFIG.laneHeight;
@@ -351,27 +365,22 @@ const GitTimeline = (() => {
             const ongoing = isOngoing(branch);
 
             branch.commits.forEach((commit, idx) => {
-                // Position commits along the branch:
-                // - idx 0 sits near the branch start
-                // - subsequent commits use their own date if available,
-                //   otherwise fall back to a fixed horizontal stride (220px)
-                let commitX;
-                if (idx === 0) {
-                    commitX = branch._startX + CONFIG.curveRadius + 10;
-                } else {
-                    const commitDate = parseDate(commit.date);
-                    if (commitDate != null) {
-                        commitX = yearToX(commitDate);
-                    } else {
-                        commitX = branch._startX + CONFIG.curveRadius + 10 + (idx * 220);
+                const commitX = commitXFor(branch, commit, idx);
+
+                // Vertical stagger:
+                // - Single commit OR first commit of a multi-commit branch:
+                //   sit centered on the branch line (-14).
+                // - Subsequent commits: stay on the line if the previous
+                //   commit is far enough horizontally; otherwise alternate
+                //   above/below to avoid overlap (+22 = below the line).
+                let verticalStagger = -14;
+                if (idx > 0) {
+                    const prevX = commitXFor(branch, branch.commits[idx - 1], idx - 1);
+                    const gap = commitX - prevX;
+                    if (gap < STAGGER_THRESHOLD) {
+                        verticalStagger = (idx % 2 === 1) ? 22 : -14;
                     }
                 }
-
-                // All markers sit just above the branch line for visual
-                // consistency. The compact label (markerLabel) keeps things
-                // single-line so multiple commits on the same branch (e.g. CBA)
-                // can sit on the same horizontal axis without colliding.
-                const verticalStagger = -14;
 
                 const marker = document.createElement('div');
                 marker.className = `git-commit-marker git-commit-${branch.type} ${ongoing ? 'ongoing' : ''}`;
@@ -387,15 +396,18 @@ const GitTimeline = (() => {
                 const endYear = ongoing ? 'Present' : branch.endDate.split('-')[0];
                 const dateRange = `${startYear} - ${endYear}`;
 
-                // Compact marker label:
-                // - Projects: just the project name (branch.name) — e.g. "Skoolbook"
-                // - Work/education: details.markerLabel if present, else details.title
+                // Compact marker label, in priority order:
+                // 1. commit.details.markerLabel (per-commit override, e.g. "Skoolbook")
+                // 2. branch.name (for single-commit branches: "Ride My Park")
+                // 3. commit.details.title (final fallback)
                 // The full title always shows in the hover overlay for context.
                 let displayTitle;
-                if (branch.type === 'project') {
+                if (commit.details.markerLabel) {
+                    displayTitle = commit.details.markerLabel;
+                } else if (branch.type === 'project') {
                     displayTitle = branch.name;
                 } else {
-                    displayTitle = commit.details.markerLabel || commit.details.title;
+                    displayTitle = commit.details.title;
                 }
 
                 marker.innerHTML = `
@@ -675,12 +687,15 @@ const GitTimeline = (() => {
                 const endYear = ongoing ? 'Present' : branch.endDate.split('-')[0];
                 const dateRange = `${startYear} - ${endYear}`;
 
-                // Format title based on type (mirror desktop logic)
+                // Format title (mirror desktop logic):
+                // markerLabel > branch.name (for projects) > details.title
                 let displayTitle;
-                if (branch.type === 'project') {
+                if (commit.details.markerLabel) {
+                    displayTitle = commit.details.markerLabel;
+                } else if (branch.type === 'project') {
                     displayTitle = branch.name;
                 } else {
-                    displayTitle = commit.details.markerLabel || commit.details.title;
+                    displayTitle = commit.details.title;
                 }
 
                 const commitEl = document.createElement('div');

--- a/frontend/themes/blueprint/blueprint.css
+++ b/frontend/themes/blueprint/blueprint.css
@@ -326,14 +326,10 @@ body[data-theme="blueprint"] .hero-content {
   text-align: center;
 }
 
+/* Hero now centers on the citation. The big SALUT/HEY headline is hidden
+   so the manifesto can speak for itself, signed "— Tom" at the bottom. */
 body[data-theme="blueprint"] .hero-title {
-  font-family: var(--font-technical);
-  font-size: clamp(3rem, 10vw, 8rem);
-  font-weight: 700;
-  line-height: 1.1;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  align-items: center;
+  display: none;
 }
 
 body[data-theme="blueprint"] .title-line {
@@ -356,22 +352,32 @@ body[data-theme="blueprint"] .hero-subtitle {
   animation-delay: 1.5s;
 }
 
-/* Paragraph form: tighter letter-spacing, slightly bigger size for body readability */
+/* Manifesto: small mono, left-aligned, no big * markers — keeps the
+   blueprint type (technical mono) but stays understated. */
 body[data-theme="blueprint"] .hero-subtitle.hero-quote {
-  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  font-size: clamp(0.95rem, 1.2vw, 1.05rem);
   letter-spacing: 0.02em;
   max-width: 640px;
-  margin: var(--spacing-md) auto var(--spacing-lg);
+  margin: var(--spacing-md) auto 0;
   text-align: left;
-  line-height: 1.75;
+  line-height: 1.7;
+  color: var(--text-primary, #fff);
 }
 
 body[data-theme="blueprint"] .annotation-mark {
-  color: var(--accent-redline);
+  display: none;
 }
 
-body[data-theme="blueprint"] .annotation-mark::before {
-  content: '*';
+/* Signature: technical mono, redline color, left-aligned same column */
+body[data-theme="blueprint"] .hero-signature {
+  font-family: var(--font-technical);
+  font-size: 0.9rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent-redline);
+  text-align: left;
+  max-width: 640px;
+  margin: 0.75rem auto 0;
 }
 
 /* Hero Annotation (Handwritten) */

--- a/frontend/themes/default/default.css
+++ b/frontend/themes/default/default.css
@@ -170,46 +170,23 @@ body[data-theme="default"] .hero-content {
   z-index: 1;
 }
 
+/* Hero centers on the manifesto — small, clean, left-aligned, no
+   decorative quote glyph, no italic. SALUT is hidden, the citation
+   IS the hero, signed "— Tom" right below. */
 body[data-theme="default"] .hero-title {
-  margin-bottom: var(--spacing-lg);
-  max-width: 720px;
-  margin-left: auto;
-  margin-right: auto;
-  text-align: center;
-  padding-left: 0;
+  display: none;
 }
 
-/* Big confident greeting — anchors the hero, dominates the citation that
-   follows. Uses the accent color directly, no opacity dimming. */
-body[data-theme="default"] .hero-title .title-line {
-  display: block;
-  font-size: clamp(3rem, 7vw, 5.5rem);
-  font-weight: 800;
-  line-height: 1;
-  letter-spacing: -0.02em;
-  text-transform: none;
-  color: var(--accent);
-  -webkit-text-fill-color: var(--accent);
-  opacity: 1;
-}
-
-body[data-theme="default"] .hero-title .title-line:last-child {
-  color: var(--accent);
-  -webkit-text-fill-color: var(--accent);
-  opacity: 1;
-}
-
-/* Citation reads as a quiet supporting line under SALUT — same width,
-   centered, no heavy border or oversized decorative quote glyph. */
 body[data-theme="default"] .hero-subtitle {
-  font-size: clamp(1rem, 1.6vw, 1.2rem);
-  color: var(--text-secondary);
+  font-family: var(--font-sans, system-ui);
+  font-size: clamp(1rem, 1.3vw, 1.15rem);
+  color: var(--text-primary);
   font-weight: 400;
-  line-height: 1.7;
+  line-height: 1.65;
   max-width: 640px;
-  margin: 0 auto var(--spacing-lg);
+  margin: 0 auto;
   letter-spacing: 0;
-  text-align: center;
+  text-align: left;
   font-style: normal;
 }
 
@@ -217,6 +194,7 @@ body[data-theme="default"] .hero-quote-paragraph {
   position: relative;
   padding: 0;
   border-left: none;
+  margin: 0;
 }
 
 body[data-theme="default"] .hero-quote-paragraph::before {
@@ -225,6 +203,19 @@ body[data-theme="default"] .hero-quote-paragraph::before {
 
 body[data-theme="default"] .hero-subtitle .annotation-mark {
   display: none;
+}
+
+/* Signature on the same column, left-aligned, accent color, small */
+body[data-theme="default"] .hero-signature {
+  font-family: var(--font-sans, system-ui);
+  font-size: 0.95rem;
+  font-style: normal;
+  font-weight: 600;
+  color: var(--accent);
+  text-align: left;
+  max-width: 640px;
+  margin: 0.75rem auto 0;
+  letter-spacing: 0.02em;
 }
 
 /* Scroll Indicator - Hidden in default theme as social proof stats take this space */

--- a/frontend/themes/default/default.css
+++ b/frontend/themes/default/default.css
@@ -171,66 +171,56 @@ body[data-theme="default"] .hero-content {
 }
 
 body[data-theme="default"] .hero-title {
-  margin-bottom: var(--spacing-md);
-}
-
-body[data-theme="default"] .hero-title {
-  max-width: 640px;
+  margin-bottom: var(--spacing-lg);
+  max-width: 720px;
   margin-left: auto;
   margin-right: auto;
-  text-align: left;
-  padding-left: 1.5rem;
+  text-align: center;
+  padding-left: 0;
 }
 
+/* Big confident greeting — anchors the hero, dominates the citation that
+   follows. Uses the accent color directly, no opacity dimming. */
 body[data-theme="default"] .hero-title .title-line {
   display: block;
-  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
-  font-weight: 600;
-  line-height: 1.2;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--text-secondary);
-  opacity: 0.75;
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  text-transform: none;
+  color: var(--accent);
+  -webkit-text-fill-color: var(--accent);
+  opacity: 1;
 }
 
 body[data-theme="default"] .hero-title .title-line:last-child {
   color: var(--accent);
-  background: none;
   -webkit-text-fill-color: var(--accent);
-  opacity: 0.9;
+  opacity: 1;
 }
 
+/* Citation reads as a quiet supporting line under SALUT — same width,
+   centered, no heavy border or oversized decorative quote glyph. */
 body[data-theme="default"] .hero-subtitle {
-  font-size: clamp(1.125rem, 2.2vw, 1.4rem);
-  color: var(--text-primary);
+  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  color: var(--text-secondary);
   font-weight: 400;
-  line-height: 1.6;
-  max-width: 620px;
+  line-height: 1.7;
+  max-width: 640px;
   margin: 0 auto var(--spacing-lg);
-  letter-spacing: -0.01em;
-  text-align: left;
-  font-style: italic;
+  letter-spacing: 0;
+  text-align: center;
+  font-style: normal;
 }
 
-/* Citation feel: decorative open-quote glyph + tighter italic body */
 body[data-theme="default"] .hero-quote-paragraph {
   position: relative;
-  padding-left: 1.5rem;
-  border-left: 2px solid var(--accent);
+  padding: 0;
+  border-left: none;
 }
 
 body[data-theme="default"] .hero-quote-paragraph::before {
-  content: "“";
-  position: absolute;
-  left: 0.4rem;
-  top: -1.5rem;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 4rem;
-  line-height: 1;
-  color: var(--accent);
-  opacity: 0.35;
-  font-style: normal;
-  pointer-events: none;
+  content: none;
 }
 
 body[data-theme="default"] .hero-subtitle .annotation-mark {

--- a/frontend/themes/retro90s/retro90s.css
+++ b/frontend/themes/retro90s/retro90s.css
@@ -388,20 +388,10 @@ body[data-theme="retro90s"] .hero-content {
   z-index: 10;
 }
 
-/* Rainbow Animated Title */
+/* Hero is now the manifesto, signed "— Tom" — the giant rainbow SALUT
+   was too loud and ate the page. Hidden so the citation can breathe. */
 body[data-theme="retro90s"] .hero-title {
-  font-family: var(--font-heading);
-  font-size: clamp(3rem, 12vw, 7rem);
-  font-weight: 900;
-  text-transform: uppercase;
-  line-height: 1;
-  align-items: center;
-  margin-bottom: var(--spacing-md);
-  text-shadow:
-    3px 3px 0 var(--color-black),
-    -1px -1px 0 var(--color-white),
-    6px 6px 0 rgba(0,0,0,0.2);
-  position: relative;
+  display: none;
 }
 
 body[data-theme="retro90s"] .title-line {
@@ -409,15 +399,6 @@ body[data-theme="retro90s"] .title-line {
   animation: rainbow-text 4s linear infinite;
   cursor: pointer;
   transition: transform 0.1s;
-}
-
-body[data-theme="retro90s"] .title-line:hover {
-  transform: scale(1.05) rotate(-2deg);
-  animation-duration: 1s;
-}
-
-body[data-theme="retro90s"] .title-line:nth-child(2) {
-  animation-delay: -2s;
 }
 
 @keyframes rainbow-text {
@@ -436,26 +417,42 @@ body[data-theme="retro90s"] .hero-subtitle {
   color: var(--color-navy);
   margin-bottom: var(--spacing-md);
   text-shadow: 1px 1px 0 var(--color-white);
-  animation: subtitle-wobble 3s ease-in-out infinite;
 }
 
-/* Paragraph form: kill the wobble (unreadable on long text), keep playful body font */
+/* Citation: playful comic font, small, left-aligned, no GeoCities box */
 body[data-theme="retro90s"] .hero-subtitle.hero-quote {
   animation: none;
-  font-size: clamp(0.95rem, 1.6vw, 1.15rem);
+  font-family: var(--font-fun);
+  font-size: clamp(1rem, 1.3vw, 1.15rem);
   max-width: 640px;
-  margin: var(--spacing-sm) auto var(--spacing-md);
+  margin: var(--spacing-md) auto 0;
   text-align: left;
-  line-height: 1.7;
+  line-height: 1.65;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-navy);
+  text-shadow: 1px 1px 0 var(--color-white);
 }
 
-@keyframes subtitle-wobble {
-  0%, 100% { transform: rotate(-1deg); }
-  50% { transform: rotate(1deg); }
+body[data-theme="retro90s"] .hero-subtitle.hero-quote::before {
+  content: none;
 }
 
 body[data-theme="retro90s"] .hero-subtitle .annotation-mark {
   display: none;
+}
+
+/* Signature: handwritten-feel, left-aligned under the citation */
+body[data-theme="retro90s"] .hero-signature {
+  font-family: var(--font-fun);
+  font-size: 1rem;
+  font-weight: bold;
+  color: #ff00ff;
+  text-shadow: 1px 1px 0 var(--color-white);
+  text-align: left;
+  max-width: 640px;
+  margin: 0.75rem auto 0;
 }
 
 /* Hit Counter - Authentic LED Style */

--- a/frontend/themes/terminal/terminal.css
+++ b/frontend/themes/terminal/terminal.css
@@ -405,29 +405,46 @@ body[data-theme="terminal"] .hero-subtitle {
   text-shadow: var(--glow-primary);
 }
 
-/* Paragraph form (post-repositioning hero copy): readable size, mono, left-aligned */
+/* Citation styled as a terminal output panel — same look as the
+   typewriter box above (dark panel + green border), so it reads as
+   a continuation of the terminal session: $ cat manifesto.txt */
 body[data-theme="terminal"] .hero-subtitle.hero-quote {
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: clamp(0.9rem, 1.4vw, 1.05rem);
   letter-spacing: 0.02em;
   text-shadow: none;
-  max-width: 640px;
+  max-width: 800px;
   margin: var(--spacing-md) auto var(--spacing-lg);
   text-align: left;
   line-height: 1.75;
+  background: var(--bg-terminal-panel);
+  border: 1px solid var(--border);
+  padding: var(--spacing-md);
+  position: relative;
+}
+
+/* Prompt line above the quote: looks like a real shell command */
+body[data-theme="terminal"] .hero-subtitle.hero-quote::before {
+  content: 'tom@dev:~$ cat manifesto.txt';
+  display: block;
+  color: var(--secondary);
+  font-weight: 700;
+  margin-bottom: var(--spacing-sm);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px dashed var(--muted);
+  font-size: 1rem;
 }
 
 body[data-theme="terminal"] .hero-quote-paragraph {
   color: var(--primary);
+  padding-left: 1rem;
+  border-left: 2px solid var(--muted);
+  margin: 0;
 }
 
-body[data-theme="terminal"] .hero-subtitle .annotation-mark::before {
-  content: '>';
-  animation: blink-fast 0.5s step-end infinite;
-}
-
-body[data-theme="terminal"] .hero-subtitle .annotation-mark:last-child::before {
-  content: '<';
+/* Drop the > / < animated annotations — the cat-prefix replaces them */
+body[data-theme="terminal"] .hero-subtitle .annotation-mark {
+  display: none;
 }
 
 body[data-theme="terminal"] .hero-stats {

--- a/frontend/themes/terminal/terminal.css
+++ b/frontend/themes/terminal/terminal.css
@@ -447,6 +447,17 @@ body[data-theme="terminal"] .hero-subtitle .annotation-mark {
   display: none;
 }
 
+/* Signature inside the manifesto box — looks like a sign-off comment */
+body[data-theme="terminal"] .hero-signature {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  color: var(--secondary);
+  font-size: 0.9rem;
+  text-align: right;
+  margin: var(--spacing-sm) 0 0;
+  padding-left: 1rem;
+  letter-spacing: 0.05em;
+}
+
 body[data-theme="terminal"] .hero-stats {
   flex-direction: column;
   gap: 0.5rem;
@@ -599,6 +610,12 @@ body[data-theme="terminal"] .project-card::before {
   height: 100%;
   background: linear-gradient(135deg, rgba(51, 255, 0, 0.02) 0%, transparent 50%);
   pointer-events: none;
+  /* Reset .project-card.no-image::before's border/radius cascade leak —
+     on terminal the type badge is rendered inside the header instead, so
+     this pseudo-element is only the gradient overlay. Without these resets
+     the no-image rule would draw a giant dashed ellipse around each card. */
+  border: none;
+  border-radius: 0;
 }
 
 body[data-theme="terminal"] .project-card:hover {


### PR DESCRIPTION
## Summary
Réponse à 3 points de feedback sur la timeline /history :

1. **Auto-scroll à droite par défaut** — la timeline s'agrandit avec le temps. Désormais : `yearWidth` minimum 140px (au lieu de 48), overflow horizontal autorisé, scroll initialisé tout à droite. Les évènements récents sont visibles immédiatement, les vieux trucs restent accessibles en scrollant à gauche.

2. **Side projects compacts** — Skoolbook / Teach Tools / Studio Manifeste / Ride My Park n'affichent plus "Fondateur · ..." mais juste le nom du projet. Single line, plus respirant. (Le rôle complet reste dans l'overlay au hover.)

3. **CBA — labels courts sur la même ligne** — au lieu de "Lead Developer · Lead Front-End AgatheYOU" qui débordait + "Platform Architect (Plateforme & IA Agentique)" qui passait sous l'autre, on a maintenant `markerLabel` court par commit :
   - "Lead Front-End AgatheYou"
   - "Platform Architect"
   Les deux markers sont alignés horizontalement sur la lane CBA, à leurs vraies dates.

4. **Bonus** — typo `AgatheYOU` → `AgatheYou` corrigée dans les data git-history (FR + EN).

## Files
- `frontend/data/{fr,en}/git-history.json` — typo + champ `markerLabel` sur les 2 commits CBA
- `frontend/js/git-timeline.js` — display logic, auto-scroll right, yearWidth floor, lanes width explicite
- `frontend/css/timeline.css` — `max-width: 220px` + ellipsis sur `.marker-title`

## Test plan
- [x] Visuel sur les 4 thèmes (default, terminal, blueprint, retro90s) en FR
- [x] Visuel default theme en EN (R&D Engineer / Freelance Developer)
- [x] Auto-scroll right au chargement vérifié (markers à gauche hors viewport, NOW à droite)
- [x] Markers courts vérifiés sur CBA et tous les projets
- [ ] À tester côté Tom : hover overlay (titre complet doit toujours apparaître)