### PR TITLE
Remove Studio Manifeste & tighten Work section

### DIFF
--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -849,24 +849,6 @@ body.loading * {
   max-width: 38rem;
 }
 
-/* ─── Project category badge (Product Builder / Transformation IA) ─── */
-.project-category {
-  display: inline-block;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 0.25rem 0.55rem;
-  margin: 0 0 0.6rem;
-  border: 1px solid currentColor;
-  border-radius: 999px;
-  opacity: 0.8;
-}
-
-.project-category[data-category="transformation-ia"] {
-  opacity: 1;
-}
-
 .projects-grid-hidden {
   display: none !important;
 }

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -849,38 +849,22 @@ body.loading * {
   max-width: 38rem;
 }
 
-/* ─── Work Territories (Product Builder / Transformation IA) ─── */
-.work-territory {
-  margin-bottom: 3rem;
-}
-
-.work-territory:last-child {
-  margin-bottom: 0;
-}
-
-.work-territory-header {
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px dashed currentColor;
-  opacity: 0.95;
-}
-
-.work-territory-header > * {
-  opacity: 1;
-}
-
-.work-territory-title {
-  font-size: 1.05rem;
-  font-weight: 700;
+/* ─── Project category badge (Product Builder / Transformation IA) ─── */
+.project-category {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin: 0 0 0.25rem;
+  padding: 0.25rem 0.55rem;
+  margin: 0 0 0.6rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  opacity: 0.8;
 }
 
-.work-territory-subtitle {
-  font-size: 0.875rem;
-  margin: 0;
-  opacity: 0.7;
+.project-category[data-category="transformation-ia"] {
+  opacity: 1;
 }
 
 .projects-grid-hidden {

--- a/frontend/css/timeline.css
+++ b/frontend/css/timeline.css
@@ -23,7 +23,11 @@
 .git-timeline-section {
     position: relative;
     padding: 4rem 0 2rem 0;
-    overflow-x: hidden;
+    /* overflow-x: clip so the SVG never spills sideways, while letting the
+       commit-detail overlay overflow downwards (visible). Using clip rather
+       than hidden lets the cross-axis stay truly visible (the spec forces
+       overflow-y to auto when paired with hidden). */
+    overflow-x: clip;
     overflow-y: visible;
     width: 100%;
     max-width: 100%;

--- a/frontend/css/timeline.css
+++ b/frontend/css/timeline.css
@@ -23,7 +23,8 @@
 .git-timeline-section {
     position: relative;
     padding: 4rem 0 2rem 0;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: visible;
     width: 100%;
     max-width: 100%;
     margin-left: 0;

--- a/frontend/data/en/content.json
+++ b/frontend/data/en/content.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · AI Transformation",
-    "description": "I build products, and I help product teams fold AI into their day-to-day work. CBA · Studio Manifeste."
+    "description": "I build products, and I help product teams fold AI into their day-to-day work. CBA."
   },
   "hero": {
     "title": "HEY",

--- a/frontend/data/en/git-history.json
+++ b/frontend/data/en/git-history.json
@@ -168,28 +168,6 @@
           }
         }
       ]
-    },
-    {
-      "id": "studio-manifeste",
-      "name": "Studio Manifeste",
-      "type": "project",
-      "startDate": "2026-01",
-      "endDate": "ongoing",
-      "commits": [
-        {
-          "hash": "stm2026",
-          "date": "2026-01",
-          "message": "Co-founded Studio Manifeste",
-          "author": "Studio Manifeste",
-          "details": {
-            "title": "Co-founder",
-            "company": "Studio Manifeste",
-            "location": "studio.alphaluppi.fr",
-            "description": "AI agency for SMEs. We help SMEs integrate AI into their business — advisory, integration, training. No hype, no bullshit.",
-            "tags": ["AI Agency", "SMEs", "Co-founder", "Advisory"]
-          }
-        }
-      ]
     }
   ]
 }

--- a/frontend/data/en/now.json
+++ b/frontend/data/en/now.json
@@ -3,8 +3,6 @@
   "headerLabel": "WHERE I'M AT",
   "intro": "",
   "paragraph": [
-    { "text": "Last month I took on a 6-month mission on top of the Lead Front-End role: Platform Architect at CBA, working on the dev platform and agentic AI for product and tech teams. AgatheYou keeps shipping. " },
-    { "link": { "text": "Studio Manifeste", "url": "https://studio.alphaluppi.fr" } },
-    { "text": ", the AI agency I'm co-founding, is taking shape on the side. Two side projects in the oven, no freelance window this quarter." }
+    { "text": "Last month I took on a 6-month mission on top of the Lead Front-End role: Platform Architect at CBA, working on the dev platform and agentic AI for product and tech teams. AgatheYou keeps shipping. Two side projects in the oven, no freelance window this quarter." }
   ]
 }

--- a/frontend/data/en/projects.json
+++ b/frontend/data/en/projects.json
@@ -64,14 +64,5 @@
         "type": "MISSION (6 MONTHS)",
         "category": "transformation-ia",
         "tags": ["Agentic AI", "Platform Engineering", "Developer Experience", "Product Experience"]
-    },
-    {
-        "id": "studio-manifeste",
-        "title": "Studio Manifeste",
-        "description": "AI agency for SMEs that I'm co-founding. We help SMEs integrate AI into their business, without hype and without bullshit. Advisory, integration, training.",
-        "type": "AI AGENCY",
-        "category": "transformation-ia",
-        "url": "https://studio.alphaluppi.fr",
-        "tags": ["AI Agency", "SMEs", "Co-founder", "Advisory"]
     }
 ]

--- a/frontend/data/en/projects.json
+++ b/frontend/data/en/projects.json
@@ -4,7 +4,6 @@
         "title": "Ride My Park",
         "description": "Find nearby spots among 30K skateparks, street spots & pumptracks for BMX, Skateboard, Aggressive Inline, Freestyle Scooter on Ride My Park.",
         "type": "WEB APPLICATION",
-        "category": "product-builder",
         "url": "https://ridemypark.com",
         "images": [
             "/assets/ridemypark-mobile-store-wallpaper.jpg",
@@ -18,7 +17,6 @@
         "title": "Skoolbook",
         "description": "Skoolbook is a platform I designed with my partner, a school teacher, to optimize school library management. It offers an intuitive interface for teachers, simplifies book loan tracking, and encourages student autonomy.",
         "type": "WEB APPLICATION",
-        "category": "product-builder",
         "url": "https://skoolbook.fr",
         "images": [
             "/assets/skoolbook-landing-page.png",
@@ -33,7 +31,6 @@
         "title": "Teach Tools",
         "description": "A digital teaching assistant with innovative tools to simplify teachers' daily work. Generate exercises and images using AI.",
         "type": "AI TOOL",
-        "category": "product-builder",
         "url": "https://teach-tools.com",
         "images": [
             "/assets/teach-tools-exercise-generation.png",
@@ -48,7 +45,6 @@
         "title": "GyroDex",
         "description": "A pokedex for Animal Crossing. List and save which Animal Crossing creatures you've collected, with friends. Full vibe coding to have fun with AI.",
         "type": "WEB APP",
-        "category": "product-builder",
         "url": "https://v0-animal-crossing-gyroides.vercel.app",
         "images": [
             "/assets/girodex-gyroide-collection.png",
@@ -56,13 +52,5 @@
             "/assets/girodex-friends-dashboard.png"
         ],
         "tags": ["Next.js", "Vercel", "Gaming"]
-    },
-    {
-        "id": "platform-architect-cba",
-        "title": "Platform Architect @ CBA",
-        "description": "6-month mission: design and evolve a development and design platform integrating agentic capabilities, to improve efficiency, quality and autonomy of product and technical teams. Platform, tools, agents, enablement, evangelism.",
-        "type": "MISSION (6 MONTHS)",
-        "category": "transformation-ia",
-        "tags": ["Agentic AI", "Platform Engineering", "Developer Experience", "Product Experience"]
     }
 ]

--- a/frontend/data/fr/content.json
+++ b/frontend/data/fr/content.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · Transformation IA",
-    "description": "Je construis des produits, et j'aide les équipes qui en construisent à intégrer l'IA dans leur quotidien. CBA · Studio Manifeste."
+    "description": "Je construis des produits, et j'aide les équipes qui en construisent à intégrer l'IA dans leur quotidien. CBA."
   },
   "hero": {
     "title": "SALUT",

--- a/frontend/data/fr/git-history.json
+++ b/frontend/data/fr/git-history.json
@@ -168,28 +168,6 @@
           }
         }
       ]
-    },
-    {
-      "id": "studio-manifeste",
-      "name": "Studio Manifeste",
-      "type": "project",
-      "startDate": "2026-01",
-      "endDate": "ongoing",
-      "commits": [
-        {
-          "hash": "stm2026",
-          "date": "2026-01",
-          "message": "Co-fondation Studio Manifeste",
-          "author": "Studio Manifeste",
-          "details": {
-            "title": "Co-fondateur",
-            "company": "Studio Manifeste",
-            "location": "studio.alphaluppi.fr",
-            "description": "Agence IA pour PME. On aide les PME à intégrer l'IA dans leur métier — conseil, intégration, formation. Sans hype et sans bullshit.",
-            "tags": ["Agence IA", "PME", "Co-fondateur", "Conseil"]
-          }
-        }
-      ]
     }
   ]
 }

--- a/frontend/data/fr/now.json
+++ b/frontend/data/fr/now.json
@@ -3,8 +3,6 @@
   "headerLabel": "OÙ J'EN SUIS",
   "intro": "",
   "paragraph": [
-    { "text": "Le mois dernier j'ai pris une mission de 6 mois en plus du Lead Front-End : Platform Architect chez CBA, sur la plateforme dev et l'IA agentique pour les équipes produit et tech. AgatheYou continue d'évoluer en prod. " },
-    { "link": { "text": "Studio Manifeste", "url": "https://studio.alphaluppi.fr" } },
-    { "text": ", l'agence IA qu'on co-fonde, prend forme en parallèle. Deux side projects sur le feu, pas de fenêtre freelance ce trimestre." }
+    { "text": "Le mois dernier j'ai pris une mission de 6 mois en plus du Lead Front-End : Platform Architect chez CBA, sur la plateforme dev et l'IA agentique pour les équipes produit et tech. AgatheYou continue d'évoluer en prod. Deux side projects sur le feu, pas de fenêtre freelance ce trimestre." }
   ]
 }

--- a/frontend/data/fr/projects.json
+++ b/frontend/data/fr/projects.json
@@ -64,14 +64,5 @@
         "type": "MISSION (6 MOIS)",
         "category": "transformation-ia",
         "tags": ["IA Agentique", "Platform Engineering", "Developer Experience", "Product Experience"]
-    },
-    {
-        "id": "studio-manifeste",
-        "title": "Studio Manifeste",
-        "description": "Agence IA pour PME que je co-fonde. On aide les PME à intégrer l'IA dans leur métier, sans hype et sans bullshit. Conseil, intégration, formation.",
-        "type": "AGENCE IA",
-        "category": "transformation-ia",
-        "url": "https://studio.alphaluppi.fr",
-        "tags": ["Agence IA", "PME", "Co-fondateur", "Conseil"]
     }
 ]

--- a/frontend/data/fr/projects.json
+++ b/frontend/data/fr/projects.json
@@ -4,7 +4,6 @@
         "title": "Ride My Park",
         "description": "Trouvez des spots près de chez vous parmi 30K skateparks, street spots et pumptracks pour BMX, Skateboard, Roller, Trottinette Freestyle sur Ride My Park.",
         "type": "APPLICATION WEB",
-        "category": "product-builder",
         "url": "https://ridemypark.com",
         "images": [
             "/assets/ridemypark-mobile-store-wallpaper.jpg",
@@ -18,7 +17,6 @@
         "title": "Skoolbook",
         "description": "Skoolbook, c'est une appli que j'ai construite avec ma conjointe instit. L'idée : simplifier la gestion des bibliothèques de classe. Les profs peuvent suivre les emprunts facilement, et les élèves gèrent leurs livres en autonomie.",
         "type": "APPLICATION WEB",
-        "category": "product-builder",
         "url": "https://skoolbook.fr",
         "images": [
             "/assets/skoolbook-landing-page.png",
@@ -33,7 +31,6 @@
         "title": "Teach Tools",
         "description": "Des outils pour les profs. Génère des exercices et des images grâce à l'IA. Simple et pratique pour le quotidien.",
         "type": "OUTIL IA",
-        "category": "product-builder",
         "url": "https://teach-tools.com",
         "images": [
             "/assets/teach-tools-exercise-generation.png",
@@ -48,7 +45,6 @@
         "title": "GyroDex",
         "description": "Un pokédex pour Animal Crossing. Liste et permet de sauvegarder quelles créatures d'Animal Crossing vous avez collectées, avec des amis. Full vibe coding pour m'amuser avec l'IA.",
         "type": "APP WEB",
-        "category": "product-builder",
         "url": "https://v0-animal-crossing-gyroides.vercel.app",
         "images": [
             "/assets/girodex-gyroide-collection.png",
@@ -56,13 +52,5 @@
             "/assets/girodex-friends-dashboard.png"
         ],
         "tags": ["Next.js", "Vercel", "Gaming"]
-    },
-    {
-        "id": "platform-architect-cba",
-        "title": "Platform Architect @ CBA",
-        "description": "Mission de 6 mois : concevoir et faire évoluer une plateforme de développement et de conception, intégrant des capacités agentiques, pour améliorer l'efficacité, la qualité et l'autonomie des équipes produit et techniques. Plateforme, outils, agents, accompagnement, vulgarisation.",
-        "type": "MISSION (6 MOIS)",
-        "category": "transformation-ia",
-        "tags": ["IA Agentique", "Platform Engineering", "Developer Experience", "Product Experience"]
     }
 ]

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · AI Transformation",
-    "description": "I build products, and I help product teams fold AI into their day-to-day work. CBA · Studio Manifeste."
+    "description": "I build products, and I help product teams fold AI into their day-to-day work. CBA."
   },
   "hero": {
     "title": "HEY",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -102,12 +102,6 @@
     "headerLabel": "WHERE I'M AT",
     "intro": ""
   },
-  "work": {
-    "categories": {
-      "productBuilder": "Product Builder",
-      "transformationIa": "AI Transformation"
-    }
-  },
   "writing": {
     "intro": "Notes, posts, and what I'm learning while building."
   },

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -103,13 +103,9 @@
     "intro": ""
   },
   "work": {
-    "productBuilder": {
-      "title": "PRODUCT BUILDER",
-      "subtitle": "Products I'm building, with teams or solo."
-    },
-    "transformationIa": {
-      "title": "AI TRANSFORMATION",
-      "subtitle": "Missions where I help product and tech teams fold AI into their stack."
+    "categories": {
+      "productBuilder": "Product Builder",
+      "transformationIa": "AI Transformation"
     }
   },
   "writing": {

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -103,13 +103,9 @@
     "intro": ""
   },
   "work": {
-    "productBuilder": {
-      "title": "PRODUCT BUILDER",
-      "subtitle": "Produits que je construis, en équipe ou en solo."
-    },
-    "transformationIa": {
-      "title": "TRANSFORMATION IA",
-      "subtitle": "Missions où j'aide des équipes produit et tech à intégrer l'IA dans leur stack."
+    "categories": {
+      "productBuilder": "Product Builder",
+      "transformationIa": "Transformation IA"
     }
   },
   "writing": {

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -102,12 +102,6 @@
     "headerLabel": "OÙ J'EN SUIS",
     "intro": ""
   },
-  "work": {
-    "categories": {
-      "productBuilder": "Product Builder",
-      "transformationIa": "Transformation IA"
-    }
-  },
   "writing": {
     "intro": "Notes, posts, et ce que j'apprends en construisant."
   },

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "Tom Andrieu",
     "title": "Product Builder · Transformation IA",
-    "description": "Je construis des produits, et j'aide les équipes qui en construisent à intégrer l'IA dans leur quotidien. CBA · Studio Manifeste."
+    "description": "Je construis des produits, et j'aide les équipes qui en construisent à intégrer l'IA dans leur quotidien. CBA."
   },
   "hero": {
     "title": "SALUT",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -371,27 +371,11 @@
     <!-- Hidden legacy grid (kept for back-compat with theme-init renderProjects fallback) -->
     <div id="projects-grid" class="projects-grid projects-grid-hidden" hidden></div>
 
-    <!-- Territory 1: Product Builder -->
-    <div class="work-territory" id="territory-product-builder">
-      <header class="work-territory-header">
-        <h3 class="work-territory-title" data-i18n="work.productBuilder.title">PRODUCT BUILDER</h3>
-        <p class="work-territory-subtitle" data-i18n="work.productBuilder.subtitle">Lead Front-End @ CBA · AgatheYOU · side projects.</p>
-      </header>
-      <div id="work-product-builder-grid" class="projects-grid">
-        <div class="projects-grid-loading">
-          <span class="loading-text" data-i18n="ui.loadingProjects">Chargement des projets...</span>
-          <span class="loading-spinner">⣾⣽⣻⢿⡿⣟⣯⣷</span>
-        </div>
+    <div id="work-grid" class="projects-grid">
+      <div class="projects-grid-loading">
+        <span class="loading-text" data-i18n="ui.loadingProjects">Chargement des projets...</span>
+        <span class="loading-spinner">⣾⣽⣻⢿⡿⣟⣯⣷</span>
       </div>
-    </div>
-
-    <!-- Territory 2: Transformation IA -->
-    <div class="work-territory" id="territory-transformation-ia">
-      <header class="work-territory-header">
-        <h3 class="work-territory-title" data-i18n="work.transformationIa.title">TRANSFORMATION IA</h3>
-        <p class="work-territory-subtitle" data-i18n="work.transformationIa.subtitle">Plateforme & IA agentique chez CBA.</p>
-      </header>
-      <div id="work-transformation-ia-grid" class="projects-grid"></div>
     </div>
 
     <div class="section-footer">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tom Andrieu — Product Builder · Transformation IA</title>
-  <meta name="description" content="Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits. CBA · AgatheYOU · Studio Manifeste." />
+  <meta name="description" content="Product Builder et Transformation IA. Je construis des produits, et je transforme par l'IA les équipes qui construisent des produits. CBA · AgatheYOU." />
 
   <!-- PostHog Analytics (centralized) -->
   <script src="/js/analytics.js"></script>
@@ -389,7 +389,7 @@
     <div class="work-territory" id="territory-transformation-ia">
       <header class="work-territory-header">
         <h3 class="work-territory-title" data-i18n="work.transformationIa.title">TRANSFORMATION IA</h3>
-        <p class="work-territory-subtitle" data-i18n="work.transformationIa.subtitle">Plateforme & IA agentique chez CBA, agence IA chez Studio Manifeste.</p>
+        <p class="work-territory-subtitle" data-i18n="work.transformationIa.subtitle">Plateforme & IA agentique chez CBA.</p>
       </header>
       <div id="work-transformation-ia-grid" class="projects-grid"></div>
     </div>

--- a/frontend/js/core/card-renderer.js
+++ b/frontend/js/core/card-renderer.js
@@ -97,6 +97,18 @@ const CardRenderer = (() => {
             ${footer}${corners}
         `;
 
+        if (project.category) {
+            const camel = project.category.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+            const label = window.LanguageManager?.t(`work.categories.${camel}`);
+            if (label) {
+                const badge = document.createElement('span');
+                badge.className = 'project-category';
+                badge.setAttribute('data-category', project.category);
+                badge.textContent = label;
+                card.querySelector('.project-info')?.prepend(badge);
+            }
+        }
+
         cfg.onRender?.(card, project, index);
         return card;
     }

--- a/frontend/js/core/card-renderer.js
+++ b/frontend/js/core/card-renderer.js
@@ -97,18 +97,6 @@ const CardRenderer = (() => {
             ${footer}${corners}
         `;
 
-        if (project.category) {
-            const camel = project.category.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-            const label = window.LanguageManager?.t(`work.categories.${camel}`);
-            if (label) {
-                const badge = document.createElement('span');
-                badge.className = 'project-category';
-                badge.setAttribute('data-category', project.category);
-                badge.textContent = label;
-                card.querySelector('.project-info')?.prepend(badge);
-            }
-        }
-
         cfg.onRender?.(card, project, index);
         return card;
     }

--- a/frontend/js/core/theme-init.js
+++ b/frontend/js/core/theme-init.js
@@ -13,14 +13,9 @@ const ThemeInit = (() => {
             await ContentLoader.loadAndPopulate();
 
             const projects = await ContentLoader.loadProjects();
-            const builderProjects = projects.filter(p => p.category === 'product-builder');
-            const transformProjects = projects.filter(p => p.category === 'transformation-ia');
 
-            if (document.querySelector('#work-product-builder-grid')) {
-                CardRenderer.renderProjects(builderProjects, config.cards || {}, '#work-product-builder-grid');
-            }
-            if (document.querySelector('#work-transformation-ia-grid')) {
-                CardRenderer.renderProjects(transformProjects, config.cards || {}, '#work-transformation-ia-grid');
+            if (document.querySelector('#work-grid')) {
+                CardRenderer.renderProjects(projects, config.cards || {}, '#work-grid');
             }
 
             // Back-compat: if a legacy single grid is present, render all there.


### PR DESCRIPTION
## Summary

- Retire toutes les références à Studio Manifeste du site (pas encore officiel, accord CBA non obtenu).
- Recentre /Work sur les produits *buildés* : 4 cartes (Ride My Park, Skoolbook, Teach Tools, GyroDex). Platform Architect (mission) reste dans /Now et dans la timeline /Historique, où elle a sa place.
- Au passage : fusionne les deux territoires Builder/Transformation IA en une seule grille (avait laissé Platform Architect orpheline), puis simplifie en retirant le badge catégorie devenu mono-valeur.
- Fix bug crop popup timeline : la section avait \`overflow: hidden\` ; passe en \`overflow-x: clip\` pour que l'axe Y reste vraiment \`visible\` (sinon la spec CSS force \`overflow-y: auto\`).

## Commits

- \`9e9e340\` content: remove Studio Manifeste references (meta, hero, /now, projects, timeline)
- \`2fa460c\` work: merge two territories into single grid with category badges
- \`fa58a1a\` work: drop Platform Architect card from work grid (+ cleanup badge)
- \`61d219b\` fix(timeline): allow overlay popup to overflow vertically (n'a pas suffi)
- \`444b647\` fix(timeline): use overflow-x: clip so popup truly overflows vertically

## Test plan

- [x] FR + EN, thèmes default / terminal / blueprint / retro90s : 0 occurrence Studio Manifeste, 4 cartes Work
- [x] Popup timeline Platform Architect entièrement visible (titre, lieu, description, tous les tags)
- [x] JSON valides
- [ ] Re-vérifier en staging avant merge