### PR TITLE
Fix unlit (black) 3D heart — double-sided material + fill lighting

### DIFF
--- a/frontend/js/experiments/heart.js
+++ b/frontend/js/experiments/heart.js
@@ -34,7 +34,8 @@ const camera = new THREE.PerspectiveCamera(
 camera.position.set(0, 0.6, 4.2);
 
 // --- Lighting -------------------------------------------------------------
-scene.add(new THREE.AmbientLight(0xffffff, 0.35));
+scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+scene.add(new THREE.HemisphereLight(0xffd9e6, 0x2a0a18, 0.7));
 
 const key = new THREE.DirectionalLight(0xffd9e6, 2.2);
 key.position.set(3, 4, 5);
@@ -57,6 +58,9 @@ const material = new THREE.MeshPhysicalMaterial({
   clearcoatRoughness: 0.18,
   sheen: 0.6,
   sheenColor: new THREE.Color(0xff8fb0),
+  // Render both faces so the surface is lit regardless of triangle winding —
+  // Three orients the shading normal toward the viewer on double-sided meshes.
+  side: THREE.DoubleSide,
 });
 
 const heart = new THREE.Group();


### PR DESCRIPTION
## Problem

On device the heart loaded and the UI rendered, but the mesh appeared as a **flat black silhouette** — no shading. The marching-cubes surface lighting depended on triangle winding + face culling, so the camera-facing surface wasn't being lit.

## Fix

- Set the material to **`THREE.DoubleSide`**: Three orients the shading normal toward the viewer on double-sided meshes, so the visible surface is always lit regardless of triangle winding.
- Added a **`HemisphereLight`** fill and bumped ambient (0.35 → 0.5) for softer, fuller shading.

The initial camera position is the front view, so the heart shape is visible immediately; the elliptical look in the earlier screenshots was just a profile angle caught mid auto-rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY9kKzArrGk68RAjyQhDTa)_