### PR TITLE
Redesign 3D heart as light halftone point cloud with inertial spin

### DIFF
--- a/frontend/experiments/heart.html
+++ b/frontend/experiments/heart.html
@@ -6,28 +6,28 @@
     name="viewport"
     content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
   />
-  <meta name="theme-color" content="#0b0410" />
+  <meta name="theme-color" content="#e9e9ee" />
   <title>Cœur 3D — Expérimentation</title>
   <meta
     name="description"
-    content="La surface algébrique du cœur de Taubin, rendue en vrai maillage 3D et manipulable au doigt."
+    content="La surface algébrique du cœur de Taubin, rendue en nuage de points 3D halftone et manipulable au doigt."
   />
   <style>
-    :root { color-scheme: dark; }
+    :root { color-scheme: light; }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body {
       height: 100%;
       overflow: hidden;
-      background: #0b0410;
+      background: radial-gradient(circle at 50% 38%, #f6f6f8 0%, #dadadf 70%, #cfcfd6 100%);
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      color: #f5e9f0;
+      color: #1d1d22;
       overscroll-behavior: none;
     }
     #scene {
       display: block;
       width: 100vw;
       height: 100vh;
-      /* Let OrbitControls own all touch gestures (no page scroll/zoom). */
+      /* Let our gesture handlers own all touch input (no page scroll/zoom). */
       touch-action: none;
     }
 
@@ -44,41 +44,39 @@
     .title {
       font-size: clamp(1.1rem, 4.5vw, 1.6rem);
       font-weight: 700;
-      letter-spacing: 0.02em;
-      text-shadow: 0 2px 18px rgba(224, 18, 60, 0.45);
+      letter-spacing: 0.01em;
+      color: #1a1a1f;
     }
     .eq {
       margin-top: 6px;
       font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
       font-size: clamp(0.62rem, 2.7vw, 0.8rem);
-      color: #e9aec2;
-      opacity: 0.85;
+      color: #6a6a73;
       line-height: 1.4;
     }
     .back {
       pointer-events: auto;
       flex-shrink: 0;
       text-decoration: none;
-      color: #f5e9f0;
+      color: #1d1d22;
       font-size: 0.8rem;
       padding: 8px 14px;
-      border: 1px solid rgba(255, 255, 255, 0.22);
+      border: 1px solid rgba(0, 0, 0, 0.18);
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.06);
+      background: rgba(255, 255, 255, 0.55);
       backdrop-filter: blur(8px);
       -webkit-backdrop-filter: blur(8px);
       transition: background 0.2s ease;
     }
-    .back:active { background: rgba(255, 255, 255, 0.16); }
+    .back:active { background: rgba(255, 255, 255, 0.85); }
 
     .hint {
       align-self: center;
       font-size: 0.82rem;
-      color: #e9aec2;
-      opacity: 0.75;
+      color: #6a6a73;
       text-align: center;
       animation: fade 5s ease forwards;
-      animation-delay: 4.5s;
+      animation-delay: 5s;
     }
     @keyframes fade { to { opacity: 0; } }
 
@@ -90,27 +88,26 @@
       align-items: center;
       justify-content: center;
       gap: 18px;
-      background: #0b0410;
-      color: #e9aec2;
+      background: radial-gradient(circle at 50% 38%, #f6f6f8 0%, #dadadf 100%);
+      color: #6a6a73;
       font-size: 0.9rem;
       transition: opacity 0.6s ease;
       z-index: 10;
     }
     #loader.hidden { opacity: 0; pointer-events: none; }
     .beat {
-      width: 46px; height: 46px;
-      background: #e0123c;
+      width: 40px; height: 40px;
+      background: #8a8a93;
       transform: rotate(-45deg);
       position: relative;
       animation: pump 1.1s ease-in-out infinite;
-      box-shadow: 0 0 30px rgba(224, 18, 60, 0.6);
     }
     .beat::before, .beat::after {
-      content: ""; position: absolute; width: 46px; height: 46px;
-      background: #e0123c; border-radius: 50%;
+      content: ""; position: absolute; width: 40px; height: 40px;
+      background: #8a8a93; border-radius: 50%;
     }
-    .beat::before { top: -23px; left: 0; }
-    .beat::after { left: 23px; top: 0; }
+    .beat::before { top: -20px; left: 0; }
+    .beat::after { left: 20px; top: 0; }
     @keyframes pump {
       0%, 100% { transform: rotate(-45deg) scale(1); }
       15% { transform: rotate(-45deg) scale(1.18); }
@@ -134,12 +131,12 @@
   <div class="overlay">
     <div class="top">
       <div>
-        <div class="title">Cœur 3D ❤</div>
+        <div class="title">Cœur 3D</div>
         <div class="eq">(x² + 9⁄4·y² + z² − 1)³ − x²z³ − 9⁄80·y²z³ = 0</div>
       </div>
       <a class="back" href="/">← Retour</a>
     </div>
-    <div class="hint">Glisse pour faire tourner · pince pour zoomer</div>
+    <div class="hint">Glisse pour le lancer · il garde son élan · pince pour zoomer</div>
   </div>
 
   <div id="loader">

--- a/frontend/js/experiments/heart.js
+++ b/frontend/js/experiments/heart.js
@@ -1,29 +1,26 @@
 /**
- * Interactive 3D heart — the Taubin implicit surface, rendered with Three.js.
- * Drag (one finger) to rotate, pinch (two fingers) to zoom. Built for touch.
+ * Interactive 3D heart — the Taubin implicit surface rendered as a
+ * "projected halftone" point cloud on a light backdrop. Drag to spin it;
+ * it keeps its momentum and glides to a gentle idle rotation. Pinch to zoom.
  */
 import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { buildHeartGeometry } from './heart-geometry.js';
 
 const canvas = document.getElementById('scene');
 const loader = document.getElementById('loader');
 
-// Lower the grid resolution a touch on small / low-power screens so the
-// one-time mesh build stays snappy on phones.
+// Denser grid = more points = finer halftone. Points are cheap to draw, so we
+// can afford a high sampling resolution; ease off a touch on small screens.
 const isSmall = Math.min(window.innerWidth, window.innerHeight) < 640;
-const RESOLUTION = isSmall ? 80 : 110;
+const RESOLUTION = isSmall ? 96 : 128;
 
-// --- Renderer -------------------------------------------------------------
-const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+// --- Renderer (transparent so the CSS backdrop shows through) -------------
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
-renderer.toneMapping = THREE.ACESFilmicToneMapping;
-renderer.toneMappingExposure = 1.05;
+renderer.setClearAlpha(0);
 
-// --- Scene & camera -------------------------------------------------------
 const scene = new THREE.Scene();
-scene.background = new THREE.Color('#0b0410');
 
 const camera = new THREE.PerspectiveCamera(
   45,
@@ -31,109 +28,165 @@ const camera = new THREE.PerspectiveCamera(
   0.1,
   100,
 );
-camera.position.set(0, 0.6, 4.2);
+let camDistance = 4.4;
+camera.position.set(0, 0, camDistance);
 
-// --- Lighting -------------------------------------------------------------
-scene.add(new THREE.AmbientLight(0xffffff, 0.5));
-scene.add(new THREE.HemisphereLight(0xffd9e6, 0x2a0a18, 0.7));
-
-const key = new THREE.DirectionalLight(0xffd9e6, 2.2);
-key.position.set(3, 4, 5);
-scene.add(key);
-
-const fill = new THREE.DirectionalLight(0x7aa2ff, 1.1);
-fill.position.set(-4, -1, 2);
-scene.add(fill);
-
-const rim = new THREE.DirectionalLight(0xff5d8f, 1.4);
-rim.position.set(-2, 3, -5);
-scene.add(rim);
-
-// --- The heart ------------------------------------------------------------
-const material = new THREE.MeshPhysicalMaterial({
-  color: 0xe0123c,
-  metalness: 0.0,
-  roughness: 0.28,
-  clearcoat: 1.0,
-  clearcoatRoughness: 0.18,
-  sheen: 0.6,
-  sheenColor: new THREE.Color(0xff8fb0),
-  // Render both faces so the surface is lit regardless of triangle winding —
-  // Three orients the shading normal toward the viewer on double-sided meshes.
-  side: THREE.DoubleSide,
+// --- Halftone point material ---------------------------------------------
+// Dot size and tone both vary with how much each point faces the light, so
+// lit areas read as dense pale dots and shadowed areas as small dark dots —
+// a 3D halftone. Lighting is in view space, so the shading stays fixed to the
+// camera and the form is revealed as the heart turns.
+const pointMaterial = new THREE.ShaderMaterial({
+  uniforms: {
+    uScale: { value: (window.innerHeight * renderer.getPixelRatio()) * 0.5 },
+    uSize: { value: 0.024 },
+    uLightDir: { value: new THREE.Vector3(-0.45, 0.7, 0.65).normalize() },
+    uDark: { value: new THREE.Color(0x2a2a30) },
+    uLight: { value: new THREE.Color(0xffffff) },
+  },
+  transparent: true,
+  depthTest: true,
+  depthWrite: true,
+  vertexShader: /* glsl */`
+    uniform float uScale;
+    uniform float uSize;
+    uniform vec3 uLightDir;
+    varying float vShade;
+    void main() {
+      vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+      vec3 n = normalize(normalMatrix * normal);
+      float lambert = max(dot(n, normalize(uLightDir)), 0.0);
+      float shade = 0.18 + 0.82 * lambert;
+      vShade = shade;
+      gl_Position = projectionMatrix * mvPosition;
+      // Bigger dots where brighter -> halftone tone via dot size.
+      float s = uSize * (0.45 + 0.95 * shade);
+      gl_PointSize = s * uScale / -mvPosition.z;
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform vec3 uDark;
+    uniform vec3 uLight;
+    varying float vShade;
+    void main() {
+      // Round, soft-edged dot.
+      float d = length(gl_PointCoord - vec2(0.5));
+      float alpha = smoothstep(0.5, 0.4, d);
+      if (alpha < 0.02) discard;
+      vec3 color = mix(uDark, uLight, vShade);
+      gl_FragColor = vec4(color, alpha);
+    }
+  `,
 });
 
+// --- Build the point cloud ------------------------------------------------
 const heart = new THREE.Group();
 scene.add(heart);
 
-let heartMesh = null;
-
 function buildHeart() {
-  const { positions, normals, indices } = buildHeartGeometry(RESOLUTION);
+  const { positions, normals } = buildHeartGeometry(RESOLUTION);
 
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
-  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
   geometry.computeBoundingSphere();
 
   // Centre and normalise scale so it always frames nicely.
   geometry.center();
   const r = geometry.boundingSphere ? geometry.boundingSphere.radius : 1;
-  const scale = 1.5 / r;
 
-  heartMesh = new THREE.Mesh(geometry, material);
+  const points = new THREE.Points(geometry, pointMaterial);
   // The equation's z-axis is vertical (lobes up) — stand the heart upright.
-  heartMesh.rotation.x = -Math.PI / 2;
-  heartMesh.scale.setScalar(scale);
-  heart.add(heartMesh);
+  points.rotation.x = -Math.PI / 2;
+  points.scale.setScalar(1.6 / r);
+  heart.add(points);
 }
 
-// --- Controls (touch-first) ----------------------------------------------
-const controls = new OrbitControls(camera, renderer.domElement);
-controls.enableDamping = true;
-controls.dampingFactor = 0.08;
-controls.enablePan = false;
-controls.minDistance = 2.2;
-controls.maxDistance = 8;
-controls.autoRotate = true;
-controls.autoRotateSpeed = 0.9;
-controls.rotateSpeed = 0.9;
-// One finger rotates, two fingers pinch-zoom — exactly what a phone expects.
-controls.touches = {
-  ONE: THREE.TOUCH.ROTATE,
-  TWO: THREE.TOUCH.DOLLY_ROTATE,
-};
-// Stop auto-rotating once the user grabs it; resume after a short idle.
-let idleTimer = null;
-controls.addEventListener('start', () => {
-  controls.autoRotate = false;
-  if (idleTimer) clearTimeout(idleTimer);
+// --- Inertial drag + pinch zoom (touch-first) ----------------------------
+const ROT_AXIS_Y = new THREE.Vector3(0, 1, 0);
+const ROT_AXIS_X = new THREE.Vector3(1, 0, 0);
+const IDLE_SPIN = 0.0022; // gentle self-rotation it always glides back to
+const DRAG_K = 0.006;     // finger sensitivity
+
+let velX = IDLE_SPIN; // angular velocity around world Y
+let velY = 0;         // angular velocity around world X
+const pointers = new Map();
+let dragging = false;
+let lastX = 0, lastY = 0;
+let pinchStart = 0, pinchStartDist = camDistance;
+
+function applyRotation(ax, ay) {
+  heart.rotateOnWorldAxis(ROT_AXIS_Y, ax);
+  heart.rotateOnWorldAxis(ROT_AXIS_X, ay);
+}
+
+canvas.addEventListener('pointerdown', (e) => {
+  canvas.setPointerCapture(e.pointerId);
+  pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  if (pointers.size === 1) {
+    dragging = true;
+    lastX = e.clientX;
+    lastY = e.clientY;
+  } else if (pointers.size === 2) {
+    dragging = false;
+    const pts = [...pointers.values()];
+    pinchStart = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+    pinchStartDist = camDistance;
+  }
 });
-controls.addEventListener('end', () => {
-  if (idleTimer) clearTimeout(idleTimer);
-  idleTimer = setTimeout(() => { controls.autoRotate = true; }, 2500);
+
+canvas.addEventListener('pointermove', (e) => {
+  if (!pointers.has(e.pointerId)) return;
+  pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+  if (pointers.size >= 2) {
+    const pts = [...pointers.values()];
+    const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+    if (pinchStart > 0) {
+      camDistance = THREE.MathUtils.clamp(
+        pinchStartDist * (pinchStart / dist), 2.4, 9,
+      );
+    }
+    return;
+  }
+
+  if (dragging) {
+    const dx = e.clientX - lastX;
+    const dy = e.clientY - lastY;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    velX = dx * DRAG_K;
+    velY = dy * DRAG_K;
+    applyRotation(velX, velY);
+  }
 });
+
+function endPointer(e) {
+  pointers.delete(e.pointerId);
+  if (pointers.size === 0) dragging = false;
+  if (pointers.size < 2) pinchStart = 0;
+  if (pointers.size === 1) {
+    const p = [...pointers.values()][0];
+    dragging = true;
+    lastX = p.x;
+    lastY = p.y;
+  }
+}
+canvas.addEventListener('pointerup', endPointer);
+canvas.addEventListener('pointercancel', endPointer);
 
 // --- Render loop ----------------------------------------------------------
-const clock = new THREE.Clock();
-
-// A gentle lub-dub heartbeat: two quick pulses then a rest.
-function heartbeat(t) {
-  const cycle = t % 1.1;
-  const pulse = (phase, width) =>
-    Math.exp(-Math.pow((cycle - phase) / width, 2));
-  return 1 + 0.045 * pulse(0.0, 0.06) + 0.03 * pulse(0.18, 0.07);
-}
-
 function animate() {
   requestAnimationFrame(animate);
-  const t = clock.getElapsedTime();
-  if (heartMesh) {
-    const s = (1.5 / (heartMesh.geometry.boundingSphere?.radius || 1)) * heartbeat(t);
-    heartMesh.scale.setScalar(s);
+
+  if (!dragging) {
+    // Coast on momentum, then glide back to a gentle idle spin — "the dance".
+    velX += (IDLE_SPIN - velX) * 0.018;
+    velY += (0 - velY) * 0.05;
+    applyRotation(velX, velY);
   }
-  controls.update();
+
+  camera.position.z += (camDistance - camera.position.z) * 0.12;
   renderer.render(scene, camera);
 }
 
@@ -142,10 +195,11 @@ window.addEventListener('resize', () => {
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
+  pointMaterial.uniforms.uScale.value =
+    (window.innerHeight * renderer.getPixelRatio()) * 0.5;
 });
 
 // --- Boot -----------------------------------------------------------------
-// Defer the heavy mesh build one frame so the loader can paint first.
 requestAnimationFrame(() => {
   try {
     buildHeart();


### PR DESCRIPTION
## Goal

Match the reference design (the *projected halftone 3D point cloud* heart): a light, elegant heart made of dots that spins with momentum — *"you lead, it answers, like a dance"* — instead of the dark glossy solid.

## Changes

- **Halftone point cloud**: the surface samples are rendered as `THREE.Points` with a custom shader. Each dot's **size and tone** are driven by view-space lighting — lit areas become dense pale dots, shadowed areas small dark dots — giving a 3D halftone. Round, soft-edged dots via the fragment shader.
- **Light design**: soft radial light backdrop, light-theme overlay (dark text), light loader. Transparent renderer over the CSS gradient.
- **Inertial spin**: fling it with one finger and it keeps its momentum, then glides back to a gentle idle rotation. Two-finger **pinch to zoom**. Custom pointer handling (works mouse + touch).
- Denser sampling grid (more points = finer halftone), eased back on small screens.

## Notes

- Geometry generator (`heart-geometry.js`) is unchanged — still the verified watertight Taubin surface; we just consume its vertex/normal samples as the point cloud.
- Served at `/experiments/heart.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY9kKzArrGk68RAjyQhDTa)_