### PR TITLE
fix(heart): align with caption, restore grab-to-spin, distinct dots per theme, keep scroll on theme switch

### DIFF
--- a/.claude/work/2026-06-21-195700-heart-home-polish.md
+++ b/.claude/work/2026-06-21-195700-heart-home-polish.md
@@ -1,0 +1,37 @@
+# Heart home: alignment, drag-rotate, per-theme dots, scroll memory
+
+**Status**: completed
+**Branch**: `claude/loving-heisenberg-ajx9vu`
+**Started**: 2026-06-21 19:57
+
+## Task
+Homepage 3D heart fixes requested by user:
+1. Heart not aligned with caption text below it.
+2. Restore drag-to-rotate ("grab" it) + change cursor (grab/grabbing).
+3. Make the dots change completely between themes (more distinct shapes/palettes).
+4. Preserve scroll position across theme switches (full reload currently loses it).
+
+## Files Being Modified
+- frontend/css/base.css (heart layout + cursor)
+- frontend/js/heart-home.js (drag-rotate, cursor, per-theme dot styles)
+- frontend/js/theme-manager.js (scroll save/restore across theme switch)
+
+## Progress
+- [x] Alignment: caption flows below canvas (flex), both centered on same axis
+- [x] Drag-to-rotate with inertia + grab/grabbing cursor (touch still scrolls)
+- [x] Distinct per-theme dot shapes (round/square/cross/star) + palettes + ring shape added
+- [x] Scroll restoration via sessionStorage on theme switch (smooth-scroll paused, aborts on user input)
+
+## Verification
+- node --check passes on both modified JS files.
+- No browser/GPU in this remote sandbox -> WebGL render NOT visually verified here.
+  Needs a quick local browser pass (all themes) per CLAUDE.md before merge.
+
+## Notes/Discoveries
+- Theme switch does a FULL page reload (window.location.href), so the heart
+  re-inits and already reads the new theme — but reload loses scroll, so the
+  user never scrolls back to see the new heart. Fixing scroll (4) makes (3)
+  visible. Keeping full reload; restoring scroll via sessionStorage.
+- html { scroll-behavior: smooth } must be temporarily disabled while snapping
+  scroll into place, else it animates and fights the restore loop.
+- heart-home.js currently only has the pointer "ripple" — no drag rotate.

--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -992,24 +992,30 @@ body[data-theme="terminal"] .code-comment-marker {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   overflow: hidden;
 }
+/* Canvas takes the space above the caption; the heart is centred in it, so the
+   heart and the caption end up sharing the same vertical axis (cleanly stacked,
+   no overlap). */
 .heart-experiment canvas {
-  position: absolute;
-  inset: 0;
+  position: relative;
+  flex: 1 1 auto;
   width: 100%;
-  height: 100%;
+  min-height: 0;
   display: block;
-  /* Allow normal page scrolling over the canvas on touch devices. */
+  /* Allow normal page scrolling over the canvas on touch devices while a
+     horizontal drag spins the heart. */
   touch-action: pan-y;
+  cursor: grab;
+}
+.heart-experiment canvas.grabbing {
+  cursor: grabbing;
 }
 .heart-experiment-caption {
   position: relative;
   z-index: 1;
   align-self: center;
-  margin-top: auto;
-  margin-bottom: 1.2rem;
+  margin: 0 0 1.2rem;
   font-size: 0.8rem;
   letter-spacing: 0.04em;
   color: inherit;
@@ -1017,6 +1023,7 @@ body[data-theme="terminal"] .code-comment-marker {
   pointer-events: none;
 }
 @media (prefers-reduced-motion: reduce) {
+  .heart-experiment canvas { cursor: default; }
   .heart-experiment-caption { opacity: 0.4; }
 }
 

--- a/frontend/js/heart-home.js
+++ b/frontend/js/heart-home.js
@@ -14,13 +14,15 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 import { buildHeartGeometry } from '/js/experiments/heart-geometry.js';
 
-// Per-theme look: dot shape, colours, and how violently it disintegrates.
-// shape: 0 round · 1 square · 2 cross · 3 diamond
+// Per-theme look: each theme gets a genuinely different dot — its own shape,
+// palette, size and how violently it disintegrates — so switching theme is an
+// unmistakable change, not just a recolour.
+// shape: 0 round · 1 square · 2 cross · 3 diamond · 4 ring · 5 star
 const THEME_STYLES = {
   default:  { shape: 0, colA: 0x14141a, colB: 0xb23047, accent: 0xff2e55, rainbow: 0, size: 0.022, scatter: 2.4, swirl: 1.0 },
-  terminal: { shape: 1, colA: 0x0a5a0a, colB: 0x49ff49, accent: 0xd6ffd6, rainbow: 0, size: 0.020, scatter: 3.1, swirl: 1.6 },
-  blueprint:{ shape: 2, colA: 0x4f86c6, colB: 0xeaf6ff, accent: 0x76e6ff, rainbow: 0, size: 0.025, scatter: 2.7, swirl: 0.9 },
-  retro90s: { shape: 3, colA: 0x222222, colB: 0xffffff, accent: 0xffffff, rainbow: 1, size: 0.030, scatter: 3.5, swirl: 2.2 },
+  terminal: { shape: 1, colA: 0x0a5a0a, colB: 0x49ff49, accent: 0xd6ffd6, rainbow: 0, size: 0.019, scatter: 3.1, swirl: 1.6 },
+  blueprint:{ shape: 2, colA: 0x4f86c6, colB: 0xeaf6ff, accent: 0x76e6ff, rainbow: 0, size: 0.026, scatter: 2.7, swirl: 0.9 },
+  retro90s: { shape: 5, colA: 0x6a00ff, colB: 0xffe600, accent: 0x00ffd0, rainbow: 1, size: 0.034, scatter: 3.6, swirl: 2.4 },
 };
 
 let started = false;
@@ -144,6 +146,14 @@ export function initHeart(section) {
           m = inBox * plus;
         } else if (shp == 3) {        // diamond
           m = smoothstep(0.5, 0.44, abs(p.x) + abs(p.y));
+        } else if (shp == 4) {        // ring / hollow circle
+          float r = length(p);
+          m = smoothstep(0.5, 0.42, r) * smoothstep(0.20, 0.28, r);
+        } else if (shp == 5) {        // 5-point star
+          float ang = atan(p.y, p.x);
+          float r = length(p);
+          float k = 0.30 + 0.20 * cos(5.0 * ang);
+          m = smoothstep(k, k - 0.06, r);
         } else {                      // round
           m = smoothstep(0.5, 0.42, length(p));
         }
@@ -186,29 +196,72 @@ export function initHeart(section) {
   const points = new THREE.Points(geometry, material);
   points.frustumCulled = false;
   points.rotation.x = -Math.PI / 2;
-  points.scale.setScalar(1.6 / r);
+  // A touch smaller than the canvas so the lobes/tip never clip the edges.
+  points.scale.setScalar(1.5 / r);
   heart.add(points);
   scene.add(heart);
 
   sizeToSection();
 
-  // --- Interaction (does NOT block scrolling) -----------------------------
+  // --- Interaction: grab to spin (inertial) + ripple — never blocks scroll --
   const ROT_Y = new THREE.Vector3(0, 1, 0);
+  const ROT_X = new THREE.Vector3(1, 0, 0);
   const IDLE_SPIN = reduced ? 0 : 0.0026;
+  const DRAG_K = 0.006;            // pixels -> radians
   let lastInteract = -1;
+  let dragging = false;
+  let activePointer = null;
+  let lastX = 0, lastY = 0;
+  let velX = IDLE_SPIN, velY = 0;  // current rotation velocity (coasts to idle)
 
-  function onMove(e) {
+  function pointerToNDC(e) {
     const rect = canvas.getBoundingClientRect();
     uni.uPointer.value.set(
       ((e.clientX - rect.left) / rect.width) * 2 - 1,
       -(((e.clientY - rect.top) / rect.height) * 2 - 1),
     );
     lastInteract = performance.now();
+  }
+
+  function onMove(e) {
+    if (dragging && e.pointerId === activePointer) {
+      const dx = e.clientX - lastX;
+      const dy = e.clientY - lastY;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      velX = dx * DRAG_K;
+      velY = dy * DRAG_K;
+      heart.rotateOnWorldAxis(ROT_Y, velX);
+      heart.rotateOnWorldAxis(ROT_X, velY);
+    }
+    pointerToNDC(e);
     if (reduced) requestFrame(); // wake a few frames for the ripple
   }
+
+  function onDown(e) {
+    dragging = true;
+    activePointer = e.pointerId;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    try { canvas.setPointerCapture(e.pointerId); } catch {}
+    canvas.classList.add('grabbing');
+    pointerToNDC(e);
+    requestFrame();
+  }
+
+  function onUp(e) {
+    if (e.pointerId !== activePointer) return;
+    dragging = false;
+    activePointer = null;
+    try { canvas.releasePointerCapture(e.pointerId); } catch {}
+    canvas.classList.remove('grabbing');
+  }
+
   if (!reduced) {
     canvas.addEventListener('pointermove', onMove, { passive: true });
-    canvas.addEventListener('pointerdown', onMove, { passive: true });
+    canvas.addEventListener('pointerdown', onDown, { passive: true });
+    canvas.addEventListener('pointerup', onUp, { passive: true });
+    canvas.addEventListener('pointercancel', onUp, { passive: true });
   }
 
   // --- Render loop with visibility gating ---------------------------------
@@ -220,10 +273,16 @@ export function initHeart(section) {
     rafId = 0;
     uni.uTime.value = clock.getElapsedTime();
 
-    const active = performance.now() - lastInteract < 120;
+    const active = dragging || performance.now() - lastInteract < 120;
     uni.uStrength.value += ((active ? 1 : 0) - uni.uStrength.value) * 0.12;
 
-    if (!reduced) heart.rotateOnWorldAxis(ROT_Y, IDLE_SPIN);
+    if (!reduced && !dragging) {
+      // Coast on the drag's momentum, then glide back to the gentle idle spin.
+      velX += (IDLE_SPIN - velX) * 0.02;
+      velY += (0 - velY) * 0.06;
+      heart.rotateOnWorldAxis(ROT_Y, velX);
+      heart.rotateOnWorldAxis(ROT_X, velY);
+    }
     renderer.render(scene, camera);
 
     // Keep going only while something is animating and the heart is on-screen.

--- a/frontend/js/theme-manager.js
+++ b/frontend/js/theme-manager.js
@@ -12,6 +12,7 @@ const ThemeManager = (() => {
 
     const DEFAULT_THEME = 'default';
     const STORAGE_KEY = 'portfolio_theme';
+    const SCROLL_KEY = 'portfolio_scroll';
     let currentThemeId = null;
 
     const getFromURL = () => new URLSearchParams(window.location.search).get('theme');
@@ -62,9 +63,59 @@ const ThemeManager = (() => {
 
     function switchTheme(id) {
         if (id === currentThemeId) return;
+        // Switching theme reloads the page (each theme ships its own JS), so
+        // remember where the visitor was and snap back there once it reloads.
+        try { sessionStorage.setItem(SCROLL_KEY, String(window.scrollY)); } catch {}
         const url = new URL(window.location);
         url.searchParams.set('theme', id);
         window.location.href = url.toString();
+    }
+
+    // Restore the scroll position saved by switchTheme. Content loads
+    // asynchronously and grows the page, so we keep correcting the scroll each
+    // frame until we can actually reach the saved spot (or time out / the user
+    // takes over). Smooth scroll-behavior is paused so the snap is instant.
+    function restoreScroll() {
+        let raw = null;
+        try { raw = sessionStorage.getItem(SCROLL_KEY); } catch { return; }
+        if (raw == null) return;
+        try { sessionStorage.removeItem(SCROLL_KEY); } catch {}
+
+        const target = parseInt(raw, 10);
+        if (!Number.isFinite(target) || target <= 0) return;
+
+        const html = document.documentElement;
+        const prevRestore = 'scrollRestoration' in history ? history.scrollRestoration : null;
+        if (prevRestore !== null) history.scrollRestoration = 'manual';
+        const prevBehavior = html.style.scrollBehavior;
+        html.style.scrollBehavior = 'auto';
+
+        let done = false;
+        const abort = () => finish();
+        function finish() {
+            if (done) return;
+            done = true;
+            html.style.scrollBehavior = prevBehavior;
+            if (prevRestore !== null) history.scrollRestoration = prevRestore;
+            window.removeEventListener('wheel', abort);
+            window.removeEventListener('touchstart', abort);
+            window.removeEventListener('keydown', abort);
+        }
+        window.addEventListener('wheel', abort, { passive: true });
+        window.addEventListener('touchstart', abort, { passive: true });
+        window.addEventListener('keydown', abort);
+
+        const deadline = performance.now() + 3000;
+        (function tick() {
+            if (done) return;
+            const maxY = Math.max(0, html.scrollHeight - window.innerHeight);
+            window.scrollTo(0, Math.min(target, maxY));
+            if (maxY < target && performance.now() < deadline) {
+                requestAnimationFrame(tick);
+            } else {
+                finish();
+            }
+        })();
     }
 
     function createSwitcher() {
@@ -97,6 +148,7 @@ const ThemeManager = (() => {
     }
 
     function init() {
+        restoreScroll();
         const timeout = setTimeout(() => { console.warn('[THEME] Timeout'); hideLoading(); }, 3000);
         const themeId = THEMES[getFromURL() || getSaved()] ? (getFromURL() || getSaved()) : DEFAULT_THEME;
         apply(themeId).then(() => clearTimeout(timeout));


### PR DESCRIPTION
## What & why

Fixes the homepage 3D heart based on feedback:

1. **Alignment** — the heart no longer overlaps the caption. The canvas now flows above the caption (flex layout) instead of being absolutely positioned over the whole section, so the heart and *"Built with heart — touch it."* share the same vertical centre axis and stack cleanly. The heart is also scaled a touch smaller (1.6→1.5) so the lobes/tip never clip the canvas edges.

2. **Grab to spin + cursor** — restored inertial drag-to-rotate: grab the heart and it spins, keeps its momentum, then glides back to the gentle idle spin. The cursor is now `grab` / `grabbing`. Touch devices still scroll the page normally (`touch-action: pan-y`); horizontal drags spin, vertical swipes scroll. Hover ripple is preserved, and `prefers-reduced-motion` keeps the default cursor and no interaction.

3. **Dots change per theme** — each theme now gets a genuinely different dot, not just a recolour: distinct shape + palette + size. `retro90s` now uses a **star** (with a brighter rainbow palette), and a new **ring** shape is available too. (default = round/crimson, terminal = square/green, blueprint = cross/blue, retro90s = star/rainbow.)

4. **Scroll position preserved across theme switches** — switching theme reloads the page (each theme ships its own JS), which previously bounced you back to the top. The scroll position is now saved to `sessionStorage` before the reload and snapped back afterwards. Because content loads asynchronously and grows the page, the restore keeps correcting each frame until it can reach the saved spot (3s cap), pauses CSS smooth-scroll during the snap, and aborts immediately if the visitor scrolls/keys.

> Note: this connects (3) and (4) — previously you'd switch theme, get sent to the top, and never scroll back down to see the new heart. With scroll restored, the per-theme change is actually visible.

## Files
- `frontend/css/base.css` — heart section layout + grab/grabbing cursor
- `frontend/js/heart-home.js` — drag-to-rotate, cursor toggle, per-theme dot styles, ring/star shapes
- `frontend/js/theme-manager.js` — scroll save/restore across theme switches

## Verification
- `node --check` passes on both modified JS files.
- ⚠️ No browser/GPU in the remote sandbox, so the WebGL render was **not** visually verified here. Recommend a quick local browser pass across all themes (`?theme=terminal|blueprint|retro90s`) and a console check before merge, per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016VBfQq3szfQCpE2Vj9Cdx3)_