### PR TITLE
Cathode alive: autonomous life engine + themed bubbles + Blip touch mode

### DIFF
--- a/.claude/work/2026-07-11-090000-blip-cathode-alive.md
+++ b/.claude/work/2026-07-11-090000-blip-cathode-alive.md
@@ -1,0 +1,51 @@
+# Blip mobile + Cathode alive (post-merge fixes & upgrades)
+
+**Status**: completed
+**Branch**: `claude/affectionate-wozniak-nqo7si`
+**Started**: 2026-07-11 09:00
+
+## Task
+Follow-up on the merged Blip/Cathode MR:
+1. Blip never visible on mobile → touch companion mode (pops above each tap,
+   follows drags, dozes then fades; native cursor untouched).
+2. Cursor reported unchanged on themes → removed the >=900px desktop gate
+   (half-screen windows silently kept the legacy theme cursor); Blip now runs
+   on any fine-pointer viewport. If it still looks stale in prod, it's browser
+   cache — files are fine.
+3. Cathode overlapped by scanlines/clippy/sparkles (z 9500 vs 9998-99999) →
+   z-index 2147483000, above everything except the Blip cursor. Also visible
+   below 380px now (shrinks instead of display:none).
+4. Bubble style + dialogue per theme: terminal window / atelier card /
+   blueprint annotation (handwritten) / Win95 comic box, with per-theme
+   i18n texts (`cathodeGuide.themes.*`) + per-theme bar titles + quips.
+   Proportional-font themes use fade-in lines (ch-typing is mono-only).
+5. Life engine: walks the viewport floor (fixed bottom), waddle bob, flips
+   facing (--cg-dir), spins, hops; after ~9s without scrolling she climbs
+   visible cards (they squish via .cg-perch-squish/.cg-perch-release), uses
+   timeline commit markers as stepping stones, quips in-theme, rides moving
+   perches, hops down the instant the page scrolls. Bubble flips side based
+   on her position. Retro90s status bar raises her floor. Reduced motion =
+   static dock (engine off). Power-off click still works (drops to floor,
+   sags, stops wandering); footer toggle revives.
+
+## Files Modified
+- frontend/js/core/effects/blip-cursor.js (touch mode, gate rework)
+- frontend/css/blip-cursor.css (touch visibility rules)
+- frontend/js/core/effects/cathode-guide.js (life engine, themed bubbles)
+- frontend/css/cathode-guide.css (z-index, life CSS, per-theme skins — all
+  below the vendor-kit marker)
+- frontend/i18n/locales/fr.json, en.json (themed dialogue + quips)
+
+## Verification (Playwright/Chromium, local server)
+- 4 themes × desktop: alive, z=2147483000, themed bar/text/font/paper,
+  walk/spin/jump/landing observed, bubble side-flip works.
+- Idle adventure: perched on .project-card after ~10s, squish classes fire,
+  in-theme quip shown, hops between perches, returns to floor on scroll.
+- Mobile (touch): Blip pops at tap point (no cursor hijack), Cathode alive.
+- Reduced motion: engine off, static dock 20/20, no Blip.
+- Narrow desktop 820px: Blip cursor takes over (old bug fixed).
+
+## Notes/Discoveries
+- data/projects.json moved to data/{lang}/projects.json (CLAUDE.md is stale).
+- "[ERR] API unavailable" in console = articles backend (localhost:3000),
+  pre-existing, unrelated.

--- a/frontend/css/blip-cursor.css
+++ b/frontend/css/blip-cursor.css
@@ -38,15 +38,22 @@ html.bc-active,html.bc-active *{cursor:none!important}
    Everything above this line is the vendor cursor-kit, unmodified.
    ============================================================ */
 
-/* Belt-and-suspenders: JS already gates activation on pointer type,
-   reduced-motion and viewport width, but a stray resize/JS-timing gap
-   should never leave a leftover cursor on screen. */
-@media (pointer: coarse), (prefers-reduced-motion: reduce) {
+/* Belt-and-suspenders: JS already gates activation on pointer type and
+   reduced-motion, but a stray JS-timing gap should never leave a leftover
+   cursor on screen. Reduced motion kills Blip in any mode; a coarse pointer
+   only kills the *cursor* incarnation — the touch companion (.bc-touch,
+   spawned by JS precisely for coarse pointers) is the one allowed there. */
+@media (prefers-reduced-motion: reduce) {
   #blip-cursor { display: none !important; }
 }
-@media (max-width: 899px) {
-  #blip-cursor { display: none !important; }
+@media (pointer: coarse) {
+  #blip-cursor:not(.bc-touch) { display: none !important; }
 }
+
+/* Touch companion: pops in above each tap (see onTouchPoint), then fades
+   out entirely once he's been snoozing long enough. */
+.bc.bc-touch { transition: opacity .45s ease; }
+.bc.bc-touch.bc-away { opacity: 0; }
 
 /* Discreet mode over native text fields: Blip stays on-screen (so the
    pointer never "disappears") but fades back while the browser's own

--- a/frontend/css/cathode-guide.css
+++ b/frontend/css/cathode-guide.css
@@ -318,8 +318,10 @@
 
 #cathode-guide {
   position: fixed;
-  z-index: 9500; /* under the theme/language switchers (9998/9999) and the
-                    Blip cursor (max int) — Cathode never sits on top of them */
+  z-index: 2147483000; /* above every site layer (switchers 9998/9999, retro
+                          tooltip 99999, exit-modal 1000000...) — nothing may
+                          ever cover or crop Cathode. Only the Blip cursor
+                          (2147483647, a pointer) stays above her. */
   --cg-size: 74px;
 }
 
@@ -333,10 +335,11 @@ body.loading #cathode-guide {
   visibility: hidden;
 }
 
-/* Below ~380px there's no room to do this kit justice (SPEC.md) — stay out
-   of the way entirely rather than clip the bubble or crowd the layout. */
+/* Below ~380px: shrink instead of vanishing — she's part of the site's
+   personality now, so she stays, just smaller and with a narrower bubble. */
 @media (max-width: 379px) {
-  #cathode-guide { display: none; }
+  #cathode-guide { --cg-size: 46px; }
+  #cathode-guide .cg-bubble { max-width: 19ch; }
 }
 
 /* Docked bottom-left at every width (deliberately opposite the bottom-right
@@ -366,8 +369,8 @@ body.loading #cathode-guide {
    bottom-right) so it never collides with the floating CTA button, which
    docks bottom-right at every width including mobile. Only hero + #contact
    ever drive the idle state / bubble here (handled in JS); elsewhere
-   Cathode just idles quietly in the corner without reacting, to stay out
-   of the way on small screens. */
+   Cathode just idles quietly without reacting, to stay out of the way on
+   small screens. */
 @media (max-width: 899px) {
   #cathode-guide {
     --cg-size: 56px;
@@ -376,30 +379,258 @@ body.loading #cathode-guide {
   }
 }
 
-/* Per-theme phosphor / bubble paper. The kit's own root default (kept as-is
-   above) already matches the terminal theme's palette; the other three
-   themes get their own currentColor + paper tuned to look native. The
-   cream chrome shell itself never changes across themes — that's the
-   mascot's constant, on purpose. */
+/* ── Life engine (cathode-guide.js) ──────────────────────────────────────
+   Once the engine is running it owns the root's position through a single
+   translate3d (px along the floor, py above it): the static dock insets
+   above are zeroed out so the transform is the only source of truth. The
+   static rules keep applying whenever the engine is off (reduced motion,
+   no JS), so Cathode still shows up docked bottom-left in that case. */
+#cathode-guide.cg-alive {
+  left: 0;
+  right: auto;
+  bottom: 0;
+  will-change: transform;
+}
+
+/* She faces where she goes: the JS sets --cg-dir (1 right / -1 left) and
+   the whole sprite mirrors. Bubble and title bar stay unmirrored. */
+#cathode-guide .cg-sprite {
+  transform: scaleX(var(--cg-dir, 1));
+}
+
+/* Stroll waddle: a quick two-step bounce on the kit's hop wrapper. Declared
+   after the kit's own .cg-hop rules so it wins while cg-walking is set. */
+#cathode-guide.cg-walking .cg-hop {
+  animation: cg-life-waddle .46s linear infinite;
+}
+@keyframes cg-life-waddle {
+  0%   { transform: translateY(0)      rotate(-1.7deg); }
+  25%  { transform: translateY(-2.6px) rotate(0deg); }
+  50%  { transform: translateY(0)      rotate(1.7deg); }
+  75%  { transform: translateY(-2.6px) rotate(0deg); }
+  100% { transform: translateY(0)      rotate(-1.7deg); }
+}
+
+/* Full spin on herself, with a bit of squash going in and out. Runs on the
+   sprite wrapper so the shadow spins along — deliberately cartoony. */
+#cathode-guide.cg-spinning .cg-sprite {
+  animation: cg-life-spin .95s cubic-bezier(.45,.05,.55,.95) 1 both;
+}
+@keyframes cg-life-spin {
+  0%   { transform: scaleX(var(--cg-dir, 1)) rotate(0turn)   scale(1); }
+  30%  { transform: scaleX(var(--cg-dir, 1)) rotate(.38turn) scale(.9); }
+  70%  { transform: scaleX(var(--cg-dir, 1)) rotate(.8turn)  scale(.94); }
+  100% { transform: scaleX(var(--cg-dir, 1)) rotate(1turn)   scale(1); }
+}
+
+/* Airborne: light stretch while the JS flies her along the jump parabola;
+   landing: one-shot squash. Both on .cg-pop, which the kit only animates
+   during enter/exit/off — states the engine never jumps in. */
+#cathode-guide.cg-jumping .cg-pop {
+  transform: scaleY(1.07) scaleX(.95);
+}
+#cathode-guide.cg-jumping .cg-shadow {
+  transform: scaleX(.72);
+  opacity: .22;
+}
+#cathode-guide.cg-landing .cg-pop {
+  animation: cg-life-land .3s cubic-bezier(.2,.75,.3,1) 1 both;
+}
+@keyframes cg-life-land {
+  0%   { transform: scale(1.1, .84); }
+  55%  { transform: scale(.95, 1.05); }
+  100% { transform: scale(1, 1); }
+}
+
+/* What she lands on gives a little under her weight, then springs back.
+   !important so the momentary squish beats theme hover transforms; both
+   classes are removed within ~700ms by the engine. */
+.cg-perch-squish {
+  transform: translateY(3px) scale(1.015, .955) !important;
+  transform-origin: 50% 100% !important;
+  transition: transform .16s cubic-bezier(.2,.75,.3,1) !important;
+}
+.cg-perch-release {
+  transition: transform .32s cubic-bezier(.25,1.5,.45,1) !important;
+}
+
+/* While she roams, the bubble opens toward whichever side has room:
+   default = opens up-and-right (left anchor, set above); .cg-bub-right
+   restores the kit's own up-and-left orientation for the right half. */
+#cathode-guide.cg-bub-right .cg-bubble {
+  left: auto;
+  right: -4px;
+  transform-origin: calc(100% - 16px) calc(100% + 12px);
+}
+#cathode-guide.cg-bub-right .cg-bubble::after,
+#cathode-guide.cg-bub-right .cg-bubble::before {
+  left: auto;
+  right: 12px;
+}
+
+/* ── Per-theme bubble skins ──────────────────────────────────────────────
+   The bubble is no longer "a terminal window with different colors": each
+   theme gets its own fiction. Terminal keeps the kit's phosphor window
+   (dots, $ prompt, typed lines, caret). Default becomes a quiet cream
+   card. Blueprint becomes a hand-written drawing annotation. Retro90s
+   becomes a Win95-titled comic box. The cream chrome shell of the sprite
+   itself never changes across themes — that's the mascot's constant, on
+   purpose.
+
+   Typing caveat: the kit's cg-type reveal measures lines in ch, which only
+   holds for monospace faces. Terminal + blueprint use mono faces and keep
+   the typewriter; default + retro90s use proportional faces, so their
+   lines fade in (cg-life-fadeline) instead of typing, and the ch-based
+   max-width clamp is lifted to never crop a line. */
+
+/* terminal: kit look, unchanged palette */
 body[data-theme="terminal"] #cathode-guide {
   --cg-ink: #33ff00;
   --cg-ink-dim: rgba(51, 255, 0, .14);
   --cg-paper: rgba(9, 13, 7, .96);
 }
-body[data-theme="blueprint"] #cathode-guide {
-  --cg-ink: #e8f1ff;
-  --cg-ink-dim: rgba(232, 241, 255, .12);
-  --cg-paper: rgba(0, 26, 51, .96);
-}
-body[data-theme="retro90s"] #cathode-guide {
-  --cg-ink: #00ff00;
-  --cg-ink-dim: rgba(0, 255, 0, .14);
-  --cg-paper: rgba(0, 0, 0, .95);
-}
+
+/* default: warm atelier card — light paper, teal accent, DM Sans */
 body[data-theme="default"] #cathode-guide {
-  --cg-ink: #5a9d95;
-  --cg-ink-dim: rgba(61, 122, 115, .14);
-  --cg-paper: rgba(44, 40, 37, .95);
+  --cg-ink: #2c2825;
+  --cg-ink-dim: rgba(61, 122, 115, .08);
+  --cg-paper: #fffdf7;
+  font-family: 'DM Sans', -apple-system, sans-serif;
+}
+body[data-theme="default"] #cathode-guide .cg-bubble {
+  border: 1px solid rgba(61, 122, 115, .55);
+  border-radius: 10px;
+  box-shadow: 0 10px 24px rgba(44, 40, 37, .14);
+  max-width: 200px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+body[data-theme="default"] #cathode-guide .cg-bubble::after,
+body[data-theme="default"] #cathode-guide .cg-bubble::before {
+  border-color: rgba(61, 122, 115, .55);
+}
+body[data-theme="default"] #cathode-guide .cg-bar {
+  background: none;
+  border-bottom: 1px dashed rgba(61, 122, 115, .35);
+  padding: 4px 9px 3px;
+}
+body[data-theme="default"] #cathode-guide .cg-bar i { display: none; }
+body[data-theme="default"] #cathode-guide .cg-bar b {
+  margin-left: 0;
+  font-size: 8.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: #3d7a73;
+  opacity: .9;
+}
+body[data-theme="default"] #cathode-guide .cg-body { padding: 7px 9px 8px; }
+
+/* blueprint: drawing annotation — deep blue paper, dashed frame,
+   Architects Daughter handwriting */
+body[data-theme="blueprint"] #cathode-guide {
+  --cg-ink: #dcf3ff;
+  --cg-ink-dim: rgba(125, 211, 255, .1);
+  --cg-paper: rgba(8, 34, 61, .96);
+  font-family: 'Architects Daughter', 'Comic Sans MS', cursive;
+}
+body[data-theme="blueprint"] #cathode-guide .cg-bubble {
+  border: 1px dashed rgba(125, 211, 255, .8);
+  border-radius: 2px;
+  box-shadow: 0 0 0 3px rgba(8, 34, 61, .35), 4px 4px 0 rgba(0, 0, 0, .25);
+  max-width: 200px;
+  font-size: 11px;
+  line-height: 1.45;
+}
+body[data-theme="blueprint"] #cathode-guide .cg-bubble::after,
+body[data-theme="blueprint"] #cathode-guide .cg-bubble::before {
+  border-style: dashed;
+  border-top: none;
+  border-color: rgba(125, 211, 255, .8);
+}
+body[data-theme="blueprint"] #cathode-guide .cg-bar {
+  background: none;
+  border-bottom: 1px solid rgba(125, 211, 255, .4);
+  padding: 3px 8px;
+}
+body[data-theme="blueprint"] #cathode-guide .cg-bar i { display: none; }
+body[data-theme="blueprint"] #cathode-guide .cg-bar b {
+  margin-left: 0;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 7.5px;
+  letter-spacing: .18em;
+  color: #7dd3ff;
+  opacity: .95;
+}
+body[data-theme="blueprint"] #cathode-guide .cg-body {
+  padding: 6px 9px 7px;
+}
+
+/* retro90s: Win95 window meets comic strip — hard black border, magenta
+   drop, navy title bar, Comic Sans body */
+body[data-theme="retro90s"] #cathode-guide {
+  --cg-ink: #111111;
+  --cg-ink-dim: rgba(0, 0, 128, .07);
+  --cg-paper: #fffef2;
+  font-family: 'Comic Sans MS', 'Comic Neue', cursive;
+}
+body[data-theme="retro90s"] #cathode-guide .cg-bubble {
+  border: 2px solid #000;
+  box-shadow: 4px 4px 0 #ff00ff;
+  max-width: 210px;
+  font-size: 11px;
+  line-height: 1.45;
+}
+body[data-theme="retro90s"] #cathode-guide .cg-bubble::after,
+body[data-theme="retro90s"] #cathode-guide .cg-bubble::before {
+  border-color: #000;
+  border-top: none;
+}
+body[data-theme="retro90s"] #cathode-guide .cg-bar {
+  background: linear-gradient(90deg, #000080, #1084d0);
+  border-bottom: 2px solid #000;
+  padding: 3px 6px;
+}
+body[data-theme="retro90s"] #cathode-guide .cg-bar i { display: none; }
+body[data-theme="retro90s"] #cathode-guide .cg-bar b {
+  margin-left: 0;
+  color: #fff;
+  font-weight: 700;
+  font-size: 8px;
+  letter-spacing: .04em;
+  opacity: 1;
+}
+body[data-theme="retro90s"] #cathode-guide .cg-bar::after {
+  content: "×";
+  margin-left: auto;
+  width: 9px;
+  height: 9px;
+  background: #c0c0c0;
+  border: 1px solid #000;
+  color: #000;
+  font: 700 7px/8px monospace;
+  text-align: center;
+}
+body[data-theme="retro90s"] #cathode-guide .cg-body { padding: 6px 8px 7px; }
+
+/* Proportional-face themes (all but terminal): fade lines in instead of
+   the ch-typed reveal, and lift the ch clamp so nothing ever gets cropped
+   mid-word. Terminal keeps the kit's typewriter + caret untouched. */
+body[data-theme="default"] #cathode-guide .cg-bubble.cg-show .cg-line,
+body[data-theme="blueprint"] #cathode-guide .cg-bubble.cg-show .cg-line,
+body[data-theme="retro90s"] #cathode-guide .cg-bubble.cg-show .cg-line {
+  animation: cg-life-fadeline .38s ease var(--cg-delay, 0ms) both;
+  max-width: none;
+  overflow: visible;
+  white-space: normal;
+}
+body[data-theme="default"] #cathode-guide .cg-line::after,
+body[data-theme="blueprint"] #cathode-guide .cg-line::after,
+body[data-theme="retro90s"] #cathode-guide .cg-line::after {
+  display: none; /* no terminal caret outside terminal fictions */
+}
+@keyframes cg-life-fadeline {
+  0% { opacity: 0; transform: translateY(3px); }
+  100% { opacity: 1; transform: translateY(0); }
 }
 
 /* Footer "reinvoke" link (see indexInsertions) — deliberately understated,

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -100,7 +100,75 @@
     "writing": "Notes on code and life, typed between two deploys.",
     "timeline": "My path in commits. Scroll to see the full diff.",
     "about": "The human behind the screen runs on coffee and CSS.",
-    "contact": "Got an idea to build? Faster reply than a Jira ticket."
+    "contact": "Got an idea to build? Faster reply than a Jira ticket.",
+    "themes": {
+      "terminal": {
+        "hero": "boot ok. welcome to the machine, human.",
+        "now": "tail -f /var/log/tom : here's what's running right now.",
+        "work": "ls projects/ : some shine, some segfaulted first.",
+        "writing": "cat notes.md : code and life, between two deploys.",
+        "timeline": "git log --oneline : his whole path, committed here.",
+        "about": "whoami : a human running on coffee and CSS.",
+        "contact": "ping tom : replies in under 24h. really."
+      },
+      "default": {
+        "hero": "Welcome to the workshop. Everything's handmade, even me.",
+        "now": "On the bench right now: watch it take shape.",
+        "work": "His projects. The ones that shine, and the ones that resisted.",
+        "writing": "Notes on code and life, written between two releases.",
+        "timeline": "His path, step by step. Take your time scrolling.",
+        "about": "The human behind all this runs on coffee and care.",
+        "contact": "Got an idea? Write to him — quick, thoughtful replies."
+      },
+      "blueprint": {
+        "hero": "General plan: Tom's workshop. Scale 1:1, everything is real.",
+        "now": "Current revision: here's the piece on the drawing board.",
+        "work": "Section B-02: delivered works, dimensions checked on site.",
+        "writing": "Notes block: freehand sketches of code and life.",
+        "timeline": "Project phasing: every step measured and dated.",
+        "about": "Detail E-05: the author of the plans. Coffee and clean lines.",
+        "contact": "Contact annex: drop your project, reply within 24h."
+      },
+      "retro90s": {
+        "hero": "WELCOME to Tom's homepage!! You are visitor no. 001337!",
+        "now": "*** HOT NEWS *** Here's what he's hacking on RIGHT NOW!",
+        "work": "His SUPER COOL projects! Click around, totally worth it!!",
+        "writing": "His personal zine: code, life, 100% popup-free!",
+        "timeline": "His whole story! Scroll it, beats any CD-ROM!",
+        "about": "The About page: a human powered by coffee AND HTML!",
+        "contact": "Sign the guestbook or send a mail, he replies FAST!!"
+      }
+    },
+    "quips": {
+      "terminal": [
+        "chmod +x this card. done.",
+        "monitoring is better up here.",
+        "perched. uptime 100%.",
+        "no bugs found up here. weird.",
+        "sudo make me a sandwich."
+      ],
+      "default": [
+        "Better view from up here, no?",
+        "Nice work, this one.",
+        "Just doing my rounds.",
+        "Shh. I'm observing.",
+        "Comfy card, this one."
+      ],
+      "blueprint": [
+        "Site inspection: all clear.",
+        "Dimension checked: 74px. Exact.",
+        "Structure sound. Signed: C.",
+        "Viewpoint approved.",
+        "Rated load: 1 mascot."
+      ],
+      "retro90s": [
+        "THIS CARD IS SO COOL!!",
+        "Amazing view ★★★★★",
+        "CLIMB SUCCESSFUL! +100 pts",
+        "I'm the webmaster up here!",
+        "Best spot on the site!!"
+      ]
+    }
   },
   "stats": {
     "yearsExperience": "Years Experience",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -100,7 +100,75 @@
     "writing": "Des notes de code et de vie, tapées entre deux deploys.",
     "timeline": "Mon parcours en commits. Scroll pour voir tout le diff.",
     "about": "L'humain derrière l'écran carbure au café et au CSS.",
-    "contact": "Une idée à construire ? Il répond plus vite qu'un ticket Jira."
+    "contact": "Une idée à construire ? Il répond plus vite qu'un ticket Jira.",
+    "themes": {
+      "terminal": {
+        "hero": "boot ok. bienvenue dans la machine, humain.",
+        "now": "tail -f /var/log/tom : voilà ce qui tourne en ce moment.",
+        "work": "ls projets/ : certains brillent, d'autres ont segfault.",
+        "writing": "cat notes.md : du code et de la vie, entre deux deploys.",
+        "timeline": "git log --oneline : tout son parcours committé ici.",
+        "about": "whoami : un humain qui carbure au café et au CSS.",
+        "contact": "ping tom : réponse en moins de 24h, si si."
+      },
+      "default": {
+        "hero": "Bienvenue dans l'atelier. Tout ici est fait main, même moi.",
+        "now": "En ce moment, sur l'établi : regardez ce qui prend forme.",
+        "work": "Ses projets. Ceux qui brillent, et ceux qui ont résisté.",
+        "writing": "Des notes de code et de vie, écrites entre deux livraisons.",
+        "timeline": "Son parcours, étape par étape. Prenez le temps de dérouler.",
+        "about": "L'humain derrière tout ça carbure au café et au détail.",
+        "contact": "Une idée en tête ? Écrivez-lui, il répond vite et bien."
+      },
+      "blueprint": {
+        "hero": "Plan général : l'atelier de Tom. Échelle 1:1, tout est réel.",
+        "now": "Révision en cours : voici la pièce sur la table à dessin.",
+        "work": "Coupe B-02 : ses ouvrages livrés, cotes vérifiées sur site.",
+        "writing": "Cartouche notes : croquis de code et de vie, à main levée.",
+        "timeline": "Phasage du chantier : chaque étape est cotée et datée.",
+        "about": "Détail E-05 : l'auteur des plans. Café et précision au trait.",
+        "contact": "Annexe contact : déposez votre projet, réponse sous 24h."
+      },
+      "retro90s": {
+        "hero": "BIENVENUE sur la homepage de Tom !! T'es le visiteur nº 001337 !",
+        "now": "*** NEWS FRAÎCHES *** Voilà ce qu'il bidouille EN CE MOMENT !",
+        "work": "Ses projets TROP COOL ! Clique partout, ça vaut le détour !!",
+        "writing": "Son zine perso : du code, de la vie, 100% sans popup !",
+        "timeline": "Toute son histoire ! Scroll, c'est mieux qu'un CD-ROM !",
+        "about": "La page About : un humain qui tourne au café ET au HTML !",
+        "contact": "Signe le guestbook ou envoie un mail, il répond VITE !!"
+      }
+    },
+    "quips": {
+      "terminal": [
+        "chmod +x cette carte. voilà.",
+        "je monitore mieux d'ici.",
+        "perchée. uptime 100%.",
+        "aucun bug détecté ici. étonnant.",
+        "sudo make me a sandwich."
+      ],
+      "default": [
+        "On voit mieux d'ici, non ?",
+        "Joli travail, celui-là.",
+        "Je fais juste ma tournée.",
+        "Chut. J'observe.",
+        "Confortable, cette carte."
+      ],
+      "blueprint": [
+        "Inspection de chantier : RAS.",
+        "Cote vérifiée : 74 px. Exact.",
+        "Structure saine. Signé : C.",
+        "Point de vue validé.",
+        "Charge admissible : 1 mascotte."
+      ],
+      "retro90s": [
+        "TROP COOL cette carte !!",
+        "Vue imprenable ★★★★★",
+        "GRIMPÉE RÉUSSIE ! +100 pts",
+        "C'est moi la webmaster ici !",
+        "Meilleur spot du site !!"
+      ]
+    }
   },
   "stats": {
     "yearsExperience": "Ans d'XP",

--- a/frontend/js/core/effects/blip-cursor.js
+++ b/frontend/js/core/effects/blip-cursor.js
@@ -9,11 +9,16 @@
  * at grid unit (6,3), and the CSS shifts the SVG by (-6s,-3s) so the origin
  * of #blip-cursor itself IS the hotspot. Positioning the div at
  * translate3d(clientX, clientY, 0) drops the tip exactly under the pointer.
+ *
+ * Two run modes, picked from the primary pointer type:
+ * - 'cursor' (fine pointer): Blip replaces the mouse pointer, any viewport.
+ * - 'touch'  (coarse pointer): no pointer to replace, so Blip becomes a tap
+ *   companion — he pops up right above each tap, follows drags with the same
+ *   spring, then dozes off and fades away until the next touch.
  */
 const BlipCursor = (() => {
     const THEMES = ['terminal', 'default', 'blueprint', 'retro90s'];
     const DEFAULT_THEME = 'default';
-    const MIN_WIDTH = 900;
 
     // Links/buttons get the "leaning toward target" hover state. Native form
     // controls are handled separately below (real caret, dimmed Blip).
@@ -30,7 +35,11 @@ const BlipCursor = (() => {
         'bc-wake': 420
     };
 
-    const SNOOZE_AFTER_MS = 25000;
+    const SNOOZE_AFTER_MS = 25000;   // cursor mode: doze off after this idle time
+    const TOUCH_SNOOZE_MS = 9000;    // touch mode: doze sooner (he's a guest, not a pointer)
+    const TOUCH_AWAY_MS = 22000;     // touch mode: fade out entirely after this
+    const TOUCH_OFFSET_X = 10;       // px right of the finger, so it doesn't cover him
+    const TOUCH_OFFSET_Y = -34;      // px above the finger
 
     // Suiveur à ressort sous-amorti : Blip traîne derrière la souris, dépasse
     // légèrement la cible et se pose avec un petit rebond (ζ ≈ 0.62).
@@ -50,8 +59,10 @@ const BlipCursor = (() => {
     let root = null;
     let isActive = false;      // module fully torn down vs. alive (init/destroy)
     let isRunning = false;     // currently attached (guards can flip this off/on live)
+    let runMode = null;        // 'cursor' | 'touch' | null
     let seenMove = false;
     let snoozing = false;
+    let away = false;          // touch mode: faded out, waiting for the next tap
     let busyUntil = 0;
     let lastMoveAt = 0;
     let lastGag = null;
@@ -68,7 +79,6 @@ const BlipCursor = (() => {
 
     let mqCoarse = null;
     let mqReduced = null;
-    let resizeTimer = null;
     let themeObserver = null;
 
     const handlers = {};
@@ -81,12 +91,13 @@ const BlipCursor = (() => {
         return !!(mqCoarse && mqCoarse.matches);
     }
 
-    function viewportWide() {
-        return window.innerWidth >= MIN_WIDTH;
-    }
-
-    function shouldRun() {
-        return !isCoarsePointer() && !prefersReduced() && viewportWide();
+    // Pointer type decides the mode; reduced-motion turns Blip off entirely.
+    // No viewport-width gate: a mouse deserves Blip even in a half-screen
+    // window (the old >=900px check silently left the legacy theme cursor in
+    // charge on smaller desktop windows).
+    function desiredMode() {
+        if (prefersReduced()) return null;
+        return isCoarsePointer() ? 'touch' : 'cursor';
     }
 
     function currentTheme() {
@@ -105,11 +116,11 @@ const BlipCursor = (() => {
         root = document.createElement('div');
         root.id = 'blip-cursor';
         root.setAttribute('aria-hidden', 'true');
-        root.className = 'bc bc-theme-' + currentTheme();
+        root.className = 'bc bc-theme-' + currentTheme() + (runMode === 'touch' ? ' bc-touch bc-away' : '');
         root.innerHTML = '<div class="bc-motion">' + SVG_MARKUP + '</div>';
         motionEl = root.firstChild;
         document.body.appendChild(root);
-        applyTransform(); // park off-screen until the first real pointermove
+        applyTransform(); // park off-screen until the first real pointermove/tap
     }
 
     function removeDom() {
@@ -172,7 +183,7 @@ const BlipCursor = (() => {
     }
 
     function idleForGags() {
-        return calm() && !root.classList.contains('bc-hover-link') && !root.classList.contains('bc-native');
+        return calm() && !away && !root.classList.contains('bc-hover-link') && !root.classList.contains('bc-native');
     }
 
     function play(cls) {
@@ -190,6 +201,10 @@ const BlipCursor = (() => {
 
     function wake() {
         lastMoveAt = Date.now();
+        if (away) {
+            away = false;
+            root.classList.remove('bc-away');
+        }
         if (snoozing) {
             snoozing = false;
             root.classList.remove('bc-snooze');
@@ -200,8 +215,12 @@ const BlipCursor = (() => {
     function activate() {
         if (!seenMove) {
             seenMove = true;
-            document.documentElement.classList.add('bc-active');
-            document.body.classList.add('blip-cursor-active');
+            // Only cursor mode hijacks the real pointer; in touch mode Blip is
+            // a companion sprite, the native touch behavior stays untouched.
+            if (runMode === 'cursor') {
+                document.documentElement.classList.add('bc-active');
+                document.body.classList.add('blip-cursor-active');
+            }
         }
         wake();
     }
@@ -230,12 +249,20 @@ const BlipCursor = (() => {
     }
 
     function startSnoozeWatch() {
+        const snoozeAfter = runMode === 'touch' ? TOUCH_SNOOZE_MS : SNOOZE_AFTER_MS;
         snoozeInterval = setInterval(() => {
-            if (!root || snoozing || !seenMove || prefersReduced()) return;
-            if (Date.now() - lastMoveAt > SNOOZE_AFTER_MS && calm()) {
+            if (!root || !seenMove || prefersReduced()) return;
+            const idleFor = Date.now() - lastMoveAt;
+            if (!snoozing && idleFor > snoozeAfter && calm()) {
                 snoozing = true;
                 root.classList.remove('bc-hover-link', 'bc-native');
                 root.classList.add('bc-snooze');
+            }
+            // Touch mode only: after snoozing a while longer, tiptoe out
+            // completely so he never squats a corner of a page being read.
+            if (runMode === 'touch' && !away && idleFor > TOUCH_AWAY_MS) {
+                away = true;
+                root.classList.add('bc-away');
             }
         }, 1000);
     }
@@ -249,6 +276,32 @@ const BlipCursor = (() => {
     function onPointerDown() {
         activate();
         play('bc-click');
+    }
+
+    // Touch mode: Blip pops up just above the finger. First appearance (or a
+    // return from bc-away) teleports him there instead of springing across
+    // the whole screen from wherever he faded out.
+    function onTouchPoint(e) {
+        if (e.pointerType && e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
+        const wasHidden = !seenMove || away;
+        targetX = e.clientX + TOUCH_OFFSET_X;
+        targetY = e.clientY + TOUCH_OFFSET_Y;
+        if (wasHidden) {
+            curX = targetX;
+            curY = targetY;
+            velX = velY = 0;
+        }
+        activate();
+        if (wasHidden) play('bc-wake');
+        else play('bc-click');
+    }
+
+    function onTouchDrag(e) {
+        if (e.pointerType && e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
+        if (!seenMove || away) return;
+        targetX = e.clientX + TOUCH_OFFSET_X;
+        targetY = e.clientY + TOUCH_OFFSET_Y;
+        lastMoveAt = Date.now();
     }
 
     function onMouseOver(e) {
@@ -267,6 +320,13 @@ const BlipCursor = (() => {
     }
 
     function attachListeners() {
+        if (runMode === 'touch') {
+            handlers.pointerdown = onTouchPoint;
+            handlers.pointermove = onTouchDrag;
+            document.addEventListener('pointerdown', handlers.pointerdown, { passive: true });
+            document.addEventListener('pointermove', handlers.pointermove, { passive: true });
+            return;
+        }
         handlers.pointermove = onPointerMove;
         handlers.pointerdown = onPointerDown;
         handlers.mouseover = onMouseOver;
@@ -285,11 +345,13 @@ const BlipCursor = (() => {
         Object.keys(handlers).forEach(k => delete handlers[k]);
     }
 
-    function start() {
+    function start(mode) {
         if (isRunning) return;
         isRunning = true;
+        runMode = mode;
         seenMove = false;
         snoozing = false;
+        away = mode === 'touch';
         busyUntil = 0;
         lastGag = null;
         curX = targetX = -100;
@@ -307,6 +369,8 @@ const BlipCursor = (() => {
     function stop() {
         if (!isRunning) return;
         isRunning = false;
+        runMode = null;
+        away = false;
         detachListeners();
         if (rafId) cancelAnimationFrame(rafId);
         rafId = null;
@@ -323,13 +387,10 @@ const BlipCursor = (() => {
 
     function evaluateActivation() {
         if (!isActive) return;
-        if (shouldRun()) start();
-        else stop();
-    }
-
-    function onResize() {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(evaluateActivation, 150);
+        const mode = desiredMode();
+        if (mode === runMode && isRunning === !!mode) return;
+        stop();
+        if (mode) start(mode);
     }
 
     function addMqListener(mq, fn) {
@@ -353,12 +414,11 @@ const BlipCursor = (() => {
         mqReduced = window.matchMedia('(prefers-reduced-motion: reduce)');
         addMqListener(mqCoarse, evaluateActivation);
         addMqListener(mqReduced, evaluateActivation);
-        window.addEventListener('resize', onResize, { passive: true });
 
         themeObserver = new MutationObserver(syncTheme);
         themeObserver.observe(document.body, { attributes: true, attributeFilter: ['data-theme'] });
 
-        if (shouldRun()) start();
+        evaluateActivation();
     }
 
     function destroy() {
@@ -367,9 +427,6 @@ const BlipCursor = (() => {
         stop();
         removeMqListener(mqCoarse, evaluateActivation);
         removeMqListener(mqReduced, evaluateActivation);
-        window.removeEventListener('resize', onResize);
-        clearTimeout(resizeTimer);
-        resizeTimer = null;
         if (themeObserver) themeObserver.disconnect();
         themeObserver = null;
         mqCoarse = null;

--- a/frontend/js/core/effects/cathode-guide.js
+++ b/frontend/js/core/effects/cathode-guide.js
@@ -1,16 +1,22 @@
 /**
  * Cathode-Guide Module
- * Cathode (the site's CRT mascot) becomes a discreet on-page guide: a small
- * fixed widget that reacts to whichever section is in view, showing a
- * terminal-style speech bubble (typed out, i18n'd) the first time each
- * section is visited, then settling into that section's idle animation.
+ * Cathode (the site's CRT mascot) is the site's living guide: she reacts to
+ * whichever section is in view (typed, i18n'd speech bubble on first visit,
+ * then that section's idle animation), and between reactions she lives her
+ * own life along the bottom edge of the viewport - strolling, spinning,
+ * hopping, and (when the visitor lingers in one spot) climbing on the site's
+ * furniture: project cards squish under her, timeline commits become
+ * stepping stones.
  *
  * Built on top of the vendor "guide-kit" (see /frontend/css/cathode-guide.css):
- * that stylesheet owns every animation/keyframe (cg-* classes, compiled from
- * beat tables - never hand-edit it). This module only creates the DOM,
- * watches scroll position via IntersectionObserver, and toggles state
- * classes + injects the bubble text, exactly per the kit's documented
- * class-based API (cg-enter / cg-enter-boot / cg-idle-* / cg-exit / cg-off).
+ * that stylesheet owns every kit animation/keyframe (cg-* classes, compiled
+ * from beat tables - never hand-edit it). This module creates the DOM,
+ * watches scroll position via IntersectionObserver, toggles state classes +
+ * injects the bubble text per the kit's class API (cg-enter / cg-enter-boot /
+ * cg-idle-* / cg-exit / cg-off), and drives the "life" layer: the root
+ * element's transform (position along the floor / on top of perches) plus
+ * the site-integration classes cg-alive/cg-walking/cg-jumping/cg-landing/
+ * cg-spinning, which live below the kit marker in the stylesheet.
  *
  * Sections observed: hero (.hero), #now, #work, #writing, #timeline, #about,
  * #contact. Any section missing from the current page (e.g. #writing isn't
@@ -22,21 +28,31 @@ const CathodeGuide = (() => {
     const TOGGLE_BTN_ID = 'cathode-guide-toggle';
     const MOBILE_QUERY = '(max-width: 899px)';
     const REDUCED_QUERY = '(prefers-reduced-motion: reduce)';
+    const THEMES = ['terminal', 'default', 'blueprint', 'retro90s'];
 
-    // Sections the guide reacts to, in document order. `barTitle` is the
-    // little terminal-tab label shown in the bubble's title bar - kept
-    // language-neutral (unix-y) on purpose, no i18n needed.
+    // Sections the guide reacts to, in document order. `bar` is the little
+    // tab label shown in the bubble's title bar, adapted to each theme's
+    // fiction (unix tab / drawing number / 90s filename / plain word).
     const SECTION_DEFS = [
-        { key: 'hero', selector: '.hero', barTitle: 'guide.sh' },
-        { key: 'now', selector: '#now', barTitle: 'now --live' },
-        { key: 'work', selector: '#work', barTitle: 'work.log' },
-        { key: 'writing', selector: '#writing', barTitle: 'blog.md' },
-        { key: 'timeline', selector: '#timeline', barTitle: 'git log' },
-        { key: 'about', selector: '#about', barTitle: 'whoami' },
-        { key: 'contact', selector: '#contact', barTitle: 'ping' }
+        { key: 'hero', selector: '.hero', bar: { terminal: 'guide.sh', default: 'bonjour', blueprint: 'PLAN A-00', retro90s: 'welcome.htm' } },
+        { key: 'now', selector: '#now', bar: { terminal: 'now --live', default: 'en ce moment', blueprint: 'REV. COURANTE', retro90s: 'news.gif' } },
+        { key: 'work', selector: '#work', bar: { terminal: 'work.log', default: 'projets', blueprint: 'COUPE B-02', retro90s: 'cool-stuff.htm' } },
+        { key: 'writing', selector: '#writing', bar: { terminal: 'blog.md', default: 'notes', blueprint: 'CARTOUCHE C-03', retro90s: 'zine.txt' } },
+        { key: 'timeline', selector: '#timeline', bar: { terminal: 'git log', default: 'parcours', blueprint: 'PHASAGE D-04', retro90s: 'history.htm' } },
+        { key: 'about', selector: '#about', bar: { terminal: 'whoami', default: 'qui suis-je', blueprint: 'DÉTAIL E-05', retro90s: 'aboutme.htm' } },
+        { key: 'contact', selector: '#contact', bar: { terminal: 'ping', default: 'contact', blueprint: 'ANNEXE F-06', retro90s: 'guestbook.htm' } }
     ];
     const SECTION_MAP = SECTION_DEFS.reduce((m, s) => { m[s.key] = s; return m; }, {});
     const MOBILE_ALLOWED = ['hero', 'contact'];
+
+    // Terminal keeps the "$ / >" prompt fiction; the other themes speak in
+    // their own voice, without a fake shell prompt.
+    const LINE_PREFIX = {
+        terminal: { first: '$ ', next: '> ' },
+        default: { first: '', next: '' },
+        blueprint: { first: '', next: '' },
+        retro90s: { first: '', next: '' }
+    };
 
     // Bubble typewriter timing - matches the kit's own CSS timing contract
     // (steps() duration + stagger), see guide-kit SPEC.md.
@@ -68,6 +84,7 @@ const CathodeGuide = (() => {
     let spriteClickHandler = null;
     let spriteKeyHandler = null;
     let languageHandler = null;
+    let reducedHandler = null;
 
     function isMobile() {
         return !!(mqMobile && mqMobile.matches);
@@ -92,9 +109,25 @@ const CathodeGuide = (() => {
         return (window.LanguageManager && LanguageManager.currentLang) || 'fr';
     }
 
+    function currentTheme() {
+        const t = document.body && document.body.dataset ? document.body.dataset.theme : null;
+        return THEMES.indexOf(t) !== -1 ? t : 'default';
+    }
+
+    // Per-theme copy with graceful fallback: cathodeGuide.themes.<theme>.<key>
+    // first, then the generic cathodeGuide.<key> used before theming existed.
+    function sectionText(key) {
+        if (!window.LanguageManager || !LanguageManager.isLoaded) return null;
+        const themedKey = 'cathodeGuide.themes.' + currentTheme() + '.' + key;
+        const themed = LanguageManager.t(themedKey);
+        if (themed && typeof themed === 'string' && themed !== themedKey) return themed;
+        const baseKey = 'cathodeGuide.' + key;
+        const base = LanguageManager.t(baseKey);
+        return (base && typeof base === 'string' && base !== baseKey) ? base : null;
+    }
+
     // Greedy word-wrap into lines the kit can type out (<=26ch incl. prefix).
-    // "$ " marks the first line, "> " continuation lines - matches the
-    // terminal-prompt look used throughout the kit's own reference demo.
+    // The line prefixes are themed (terminal keeps its "$ / >" prompt).
     function wrapLines(text, maxLines) {
         const words = String(text || '').trim().split(/\s+/).filter(Boolean);
         const raw = [];
@@ -110,20 +143,17 @@ const CathodeGuide = (() => {
         });
         if (cur) raw.push(cur);
         const limited = maxLines ? raw.slice(0, maxLines) : raw;
-        return limited.map((l, i) => (i === 0 ? '$ ' : '> ') + l);
+        const prefix = LINE_PREFIX[currentTheme()] || LINE_PREFIX.terminal;
+        return limited.map((l, i) => (i === 0 ? prefix.first : prefix.next) + l);
     }
 
-    function renderBubbleContent(key) {
+    function fillBubble(barTitle, text) {
         if (!bodyEl || !barEl) return false;
-        const def = SECTION_MAP[key];
-        const i18nKey = 'cathodeGuide.' + key;
-        const text = (window.LanguageManager && LanguageManager.isLoaded) ? LanguageManager.t(i18nKey) : null;
-        if (!text || typeof text !== 'string' || text === i18nKey) return false;
-
-        barEl.textContent = def ? def.barTitle : 'guide.sh';
+        barEl.textContent = barTitle;
         bodyEl.innerHTML = '';
-        const maxLines = isMobile() ? 1 : 3;
-        const lines = wrapLines(text, maxLines);
+        // 3 lines everywhere: she lives on the floor now, there's always
+        // vertical room, and truncating mid-sentence reads like a bug.
+        const lines = wrapLines(text, 3);
         let delay = 0;
         lines.forEach(line => {
             const span = document.createElement('span');
@@ -137,15 +167,25 @@ const CathodeGuide = (() => {
         return true;
     }
 
+    function renderBubbleContent(key) {
+        const def = SECTION_MAP[key];
+        const text = sectionText(key);
+        if (!text) return false;
+        const bar = def && def.bar ? (def.bar[currentTheme()] || def.bar.terminal) : 'guide.sh';
+        return fillBubble(bar, text);
+    }
+
     function showBubble(key) {
         if (!bubbleEl) return;
         if (!renderBubbleContent(key)) return;
+        bubbleOwner = 'section';
         bubbleEl.classList.remove('cg-hide');
         bubbleEl.classList.add('cg-show');
     }
 
     function hideBubble() {
         if (!bubbleEl) return;
+        bubbleOwner = null;
         bubbleEl.classList.remove('cg-show');
         bubbleEl.classList.add('cg-hide');
     }
@@ -209,6 +249,11 @@ const CathodeGuide = (() => {
         visited.add(key);
 
         if (firstVisit) {
+            // She has something to say: stop strolling and say it in place.
+            if (alive && (lifeState === 'walk' || lifeState === 'stand')) {
+                setLifeState('stand');
+                nextThinkAt = performance.now() + 3000;
+            }
             playEnter(key, true);
         } else {
             // Section revisited: screen state still updates, but quietly -
@@ -292,6 +337,19 @@ const CathodeGuide = (() => {
         clearTimers();
         offState = true;
         hideBubble();
+        // Powered-down TVs don't sit on shelves they climbed onto: put her
+        // back on the floor before the sag animation plays.
+        if (alive) {
+            jumpArc = null;
+            if (perchEl) {
+                perchEl.classList.remove('cg-perch-squish', 'cg-perch-release');
+                perchEl = null;
+            }
+            py = 0;
+            setLifeState('stand');
+            root.classList.remove('cg-walking', 'cg-jumping', 'cg-landing', 'cg-spinning');
+            applyLifeTransform();
+        }
         root.classList.remove('cg-enter', 'cg-enter-boot', 'cg-exit');
         root.classList.add('cg-off');
         try { localStorage.setItem(STORAGE_KEY, '1'); } catch {}
@@ -310,6 +368,8 @@ const CathodeGuide = (() => {
         root.classList.add('cg-enter');
         setIdle(key);
         setTimer(() => { if (root) root.classList.remove('cg-enter'); }, prefersReduced() ? 50 : 1700);
+        evaluateLife();
+        if (alive) nextThinkAt = performance.now() + 2500;
     }
 
     function bindToggleButton() {
@@ -317,6 +377,443 @@ const CathodeGuide = (() => {
         if (!toggleBtn) return;
         toggleHandler = () => { if (!mounted || offState) reinvoke(); };
         toggleBtn.addEventListener('click', toggleHandler);
+    }
+
+    /* ==================== Life engine ====================
+       Cathode's autonomous layer. The stylesheet's site-integration zone
+       pins the root to left:0/bottom:0 once cg-alive is set, so this engine
+       owns her position through a single translate3d: px along the floor,
+       py above it (0 = feet on the floor line). Kit animations all live on
+       inner elements, so the root transform never fights them.
+
+       She strolls, spins and hops on her own; when the visitor lingers
+       without scrolling she climbs the furniture (cards squish on landing,
+       timeline commits are stepping stones) and hops back down the moment
+       the page moves under her. Reduced motion keeps the engine off - the
+       static docked position from the stylesheet then applies unchanged. */
+
+    const LIFE = {
+        WALK_SPEED: 46,              // px/s stroll speed
+        EDGE_PAD: 10,                // min gap to the viewport edges
+        CTA_CLEARANCE: 150,          // keep clear of the bottom-right floating CTA
+        IDLE_BEFORE_CLIMB_MS: 9000,  // visitor inactivity before she climbs things
+        MAX_PERCH_HOPS: 4,           // stepping-stone hops before coming down
+        PERCH_SELECTOR: '.project-card, .git-commit-marker, .now-card, .about-card, .contact-card, .hero-cta',
+        QUIP_CHANCE: 0.65,
+        QUIP_VISIBLE_MS: 4600
+    };
+
+    let alive = false;
+    let lifeRaf = null;
+    let lifeLastTs = 0;
+    let px = 20;                 // left offset of the root, viewport px
+    let py = 0;                  // feet height above the floor line
+    let dir = 1;                 // 1 facing right, -1 facing left
+    let lifeState = 'stand';     // stand | walk | jump | perch
+    let walkTarget = 0;
+    let jumpArc = null;          // {fromX,fromY,toX,toY,start,dur,peak,perch}
+    let perchEl = null;
+    let perchHops = 0;
+    let nextThinkAt = 0;
+    let lastUserAct = 0;
+    let climbCooldownUntil = 0;  // pause between climb sessions - she's alive, not manic
+    let floorBase = 20;
+    let floorProbeAt = -1;
+    let bubbleOwner = null;      // 'section' | 'quip' - who opened the bubble
+    let lastQuip = -1;
+    const lifeTimers = new Set();
+    const lifeHandlers = {};
+
+    function lifeSetTimeout(fn, ms) {
+        const id = setTimeout(() => { lifeTimers.delete(id); fn(); }, ms);
+        lifeTimers.add(id);
+        return id;
+    }
+
+    function spriteSize() {
+        return root ? (root.offsetWidth || 74) : 74;
+    }
+
+    function lifeMaxX() {
+        return Math.max(LIFE.EDGE_PAD, window.innerWidth - spriteSize() - LIFE.CTA_CLEARANCE);
+    }
+
+    // The floor line: the old docked insets (20px desktop / 12px mobile),
+    // raised above any fixed bottom bar a theme installs (retro90s status bar).
+    function probeFloor(now) {
+        if (now - floorProbeAt < 1000 && floorProbeAt >= 0) return;
+        floorProbeAt = now;
+        let base = window.innerWidth < 900 ? 12 : 20;
+        const bar = document.querySelector('.retro-status-bar');
+        if (bar && bar.offsetHeight) base = Math.max(base, bar.offsetHeight + 6);
+        floorBase = base;
+    }
+
+    function applyLifeTransform() {
+        if (!root) return;
+        root.style.transform = 'translate3d(' + px.toFixed(1) + 'px,' + (-(floorBase + py)).toFixed(1) + 'px,0)';
+        root.style.setProperty('--cg-dir', dir < 0 ? '-1' : '1');
+        // Bubble opens toward the roomy side of the screen.
+        root.classList.toggle('cg-bub-right', px + spriteSize() / 2 > window.innerWidth / 2);
+    }
+
+    function setLifeState(s) {
+        lifeState = s;
+        if (!root) return;
+        root.classList.toggle('cg-walking', s === 'walk');
+        root.classList.toggle('cg-jumping', s === 'jump');
+    }
+
+    function bubbleShowing() {
+        return !!(bubbleEl && bubbleEl.classList.contains('cg-show'));
+    }
+
+    function startWalk(now) {
+        const lo = LIFE.EDGE_PAD, hi = lifeMaxX();
+        if (hi - lo < 40) { setLifeState('stand'); nextThinkAt = now + 2200; return; }
+        // Short strolls (≤ ~340px) keep her decisions frequent — a full
+        // viewport crossing would lock her out of reacting for ~30s.
+        const reach = 120 + Math.random() * 220;
+        walkTarget = Math.min(hi, Math.max(lo, px + (Math.random() < 0.5 ? -reach : reach)));
+        if (Math.abs(walkTarget - px) < 30) walkTarget = px > (lo + hi) / 2 ? px - reach : px + reach;
+        walkTarget = Math.min(hi, Math.max(lo, walkTarget));
+        dir = walkTarget > px ? 1 : -1;
+        setLifeState('walk');
+    }
+
+    function playSpin() {
+        if (!root) return;
+        root.classList.remove('cg-spinning');
+        void root.offsetWidth;
+        root.classList.add('cg-spinning');
+        lifeSetTimeout(() => { if (root) root.classList.remove('cg-spinning'); }, 980);
+    }
+
+    function startSpin(now) {
+        setLifeState('stand');
+        playSpin();
+        nextThinkAt = now + 1500 + Math.random() * 1400;
+    }
+
+    function startJump(toX, toY, perch, now) {
+        const dist = Math.hypot(toX - px, toY - py);
+        jumpArc = {
+            fromX: px, fromY: py, toX, toY, perch: perch || null,
+            start: now, dur: Math.min(950, 420 + dist * 0.55),
+            peak: 36 + Math.min(90, dist * 0.22)
+        };
+        if (Math.abs(toX - px) > 4) dir = toX >= px ? 1 : -1;
+        setLifeState('jump');
+    }
+
+    function perchTop(el) {
+        const r = el.getBoundingClientRect();
+        return {
+            x: r.left + r.width / 2 - spriteSize() / 2,
+            y: (window.innerHeight - r.top) - floorBase - 3
+        };
+    }
+
+    function perchCandidates() {
+        const els = document.querySelectorAll(LIFE.PERCH_SELECTOR);
+        const out = [];
+        for (let i = 0; i < els.length; i++) {
+            const el = els[i];
+            if (el === perchEl) continue;
+            const r = el.getBoundingClientRect();
+            if (!r.width || r.width < 40 || !r.height) continue;
+            // Reachable band: below the fixed header, high enough that she
+            // (and her bubble) still fit above the perch.
+            if (r.top < 80 || r.top > window.innerHeight - 120) continue;
+            const cx = r.left + r.width / 2;
+            if (cx < 20 || cx > window.innerWidth - 20) continue;
+            out.push(el);
+        }
+        return out;
+    }
+
+    function pickPerch() {
+        const c = perchCandidates();
+        if (!c.length) return null;
+        c.sort((a, b) =>
+            Math.abs(a.getBoundingClientRect().left - px) -
+            Math.abs(b.getBoundingClientRect().left - px));
+        return c[Math.floor(Math.random() * Math.min(3, c.length))];
+    }
+
+    // Stepping stones: from one timeline commit to a close-enough neighbor.
+    function nextMarkerFrom(el) {
+        if (!el || !el.classList || !el.classList.contains('git-commit-marker')) return null;
+        const from = el.getBoundingClientRect();
+        let best = null, bestDx = Infinity;
+        perchCandidates().forEach(cand => {
+            if (!cand.classList.contains('git-commit-marker')) return;
+            const r = cand.getBoundingClientRect();
+            const dx = Math.abs(r.left - from.left);
+            if (dx > 30 && dx < 420 && Math.abs(r.top - from.top) < 220 && dx < bestDx) {
+                best = cand;
+                bestDx = dx;
+            }
+        });
+        return best;
+    }
+
+    function squishPerch(el) {
+        if (!el) return;
+        el.classList.add('cg-perch-squish');
+        lifeSetTimeout(() => {
+            el.classList.remove('cg-perch-squish');
+            el.classList.add('cg-perch-release');
+            lifeSetTimeout(() => el.classList.remove('cg-perch-release'), 380);
+        }, 300);
+    }
+
+    function quipsForTheme() {
+        if (!window.LanguageManager || !LanguageManager.isLoaded) return null;
+        const key = 'cathodeGuide.quips.' + currentTheme();
+        const v = LanguageManager.t(key);
+        return Array.isArray(v) && v.length ? v : null;
+    }
+
+    // A short perched one-liner, in the current theme's voice. Never talks
+    // over a section bubble, and its auto-hide never closes someone else's.
+    function maybeQuip() {
+        if (!bubbleEl || bubbleShowing() || Math.random() > LIFE.QUIP_CHANCE) return;
+        const arr = quipsForTheme();
+        if (!arr) return;
+        let idx;
+        do { idx = Math.floor(Math.random() * arr.length); } while (arr.length > 1 && idx === lastQuip);
+        lastQuip = idx;
+        const def = SECTION_MAP[currentSectionKey];
+        const bar = def && def.bar ? (def.bar[currentTheme()] || def.bar.terminal) : 'cathode';
+        if (!fillBubble(bar, arr[idx])) return;
+        bubbleOwner = 'quip';
+        bubbleEl.classList.remove('cg-hide');
+        bubbleEl.classList.add('cg-show');
+        lifeSetTimeout(() => { if (bubbleOwner === 'quip') hideBubble(); }, LIFE.QUIP_VISIBLE_MS);
+    }
+
+    function landJump(now) {
+        px = jumpArc.toX;
+        py = jumpArc.toY;
+        const perch = jumpArc.perch;
+        jumpArc = null;
+        if (root) {
+            root.classList.add('cg-landing');
+            lifeSetTimeout(() => { if (root) root.classList.remove('cg-landing'); }, 340);
+        }
+        if (perch && document.contains(perch)) {
+            perchEl = perch;
+            perchHops++;
+            setLifeState('perch');
+            squishPerch(perch);
+            nextThinkAt = now + 3800 + Math.random() * 3200;
+            lifeSetTimeout(maybeQuip, 520);
+        } else {
+            perchEl = null;
+            py = 0;
+            setLifeState('stand');
+            nextThinkAt = now + 900 + Math.random() * 2000;
+        }
+    }
+
+    function hopDown(now) {
+        perchEl = null;
+        const lo = LIFE.EDGE_PAD, hi = lifeMaxX();
+        const tx = Math.min(hi, Math.max(lo, px + (Math.random() < 0.5 ? -1 : 1) * (30 + Math.random() * 60)));
+        startJump(tx, 0, null, now);
+    }
+
+    function think(now) {
+        if (!alive || !root) return;
+        if (offState) { nextThinkAt = now + 2500; return; }
+        if (bubbleShowing() && bubbleOwner === 'section') { nextThinkAt = now + 1500; return; }
+
+        if (lifeState === 'perch') {
+            if (Math.random() < 0.25) {
+                playSpin(); // a little victory spin right there on the perch
+                nextThinkAt = now + 2500 + Math.random() * 2500;
+                return;
+            }
+            const next = nextMarkerFrom(perchEl);
+            if (next && perchHops < LIFE.MAX_PERCH_HOPS && Math.random() < 0.7) {
+                const p = perchTop(next);
+                startJump(p.x, p.y, next, now);
+            } else {
+                hopDown(now);
+                climbCooldownUntil = now + 8000 + Math.random() * 9000;
+            }
+            return;
+        }
+
+        // The visitor has settled somewhere: time to climb on things.
+        if (now - lastUserAct > LIFE.IDLE_BEFORE_CLIMB_MS && now > climbCooldownUntil) {
+            const target = pickPerch();
+            if (target) {
+                perchHops = 0;
+                const p = perchTop(target);
+                startJump(p.x, p.y, target, now);
+                return;
+            }
+        }
+
+        // Mid-walk check found nothing to climb: just keep strolling.
+        if (lifeState === 'walk') {
+            nextThinkAt = now + 2000;
+            return;
+        }
+
+        const r = Math.random();
+        if (r < 0.48) {
+            startWalk(now);
+        } else if (r < 0.60) {
+            startSpin(now);
+        } else if (r < 0.72) {
+            const tx = Math.min(lifeMaxX(), Math.max(LIFE.EDGE_PAD, px + (Math.random() - 0.5) * 90));
+            startJump(tx, 0, null, now); // playful little hop
+        } else {
+            setLifeState('stand');
+            nextThinkAt = now + 1600 + Math.random() * 3200;
+        }
+    }
+
+    function lifeTick(ts) {
+        if (!alive) return;
+        lifeRaf = requestAnimationFrame(lifeTick);
+        if (!lifeLastTs) lifeLastTs = ts;
+        let dt = (ts - lifeLastTs) / 1000;
+        lifeLastTs = ts;
+        if (dt > 0.05) dt = 0.05; // tab-return / freeze clamp
+        probeFloor(ts);
+
+        if (lifeState === 'walk') {
+            px += LIFE.WALK_SPEED * dt * dir;
+            if ((dir > 0 && px >= walkTarget) || (dir < 0 && px <= walkTarget)) {
+                px = walkTarget;
+                setLifeState('stand');
+                nextThinkAt = ts + 900 + Math.random() * 2600;
+            } else if (ts > nextThinkAt && ts - lastUserAct > LIFE.IDLE_BEFORE_CLIMB_MS) {
+                think(ts); // the visitor settled mid-stroll: allowed to climb now
+            }
+        } else if (lifeState === 'jump' && jumpArc) {
+            const t = Math.min(1, (ts - jumpArc.start) / jumpArc.dur);
+            const e = t * (2 - t); // ease-out on the horizontal
+            px = jumpArc.fromX + (jumpArc.toX - jumpArc.fromX) * e;
+            py = jumpArc.fromY + (jumpArc.toY - jumpArc.fromY) * t + jumpArc.peak * 4 * t * (1 - t);
+            if (t >= 1) landJump(ts);
+        } else if (lifeState === 'perch') {
+            if (!perchEl || !document.contains(perchEl)) {
+                perchEl = null;
+                py = 0;
+                setLifeState('stand');
+            } else {
+                const r = perchEl.getBoundingClientRect();
+                const cx = r.left + r.width / 2;
+                // Perches can move under her (page scroll is caught as user
+                // activity, but the timeline pans horizontally inside its own
+                // scroller): bail out before she gets carried off-screen.
+                if (!r.width || r.top < 60 || r.top > window.innerHeight - 60 ||
+                    cx < 30 || cx > window.innerWidth - 30) {
+                    hopDown(ts);
+                } else {
+                    // Ride the perch (hover lifts, reveal animations...).
+                    const tx = r.left + r.width / 2 - spriteSize() / 2;
+                    const ty = (window.innerHeight - r.top) - floorBase - 3;
+                    px += (tx - px) * 0.3;
+                    py += (ty - py) * 0.3;
+                }
+            }
+            if (ts > nextThinkAt) think(ts);
+        } else {
+            if (py > 0) py = Math.max(0, py - 900 * dt); // safety: settle down
+            if (ts > nextThinkAt) think(ts);
+        }
+        applyLifeTransform();
+    }
+
+    // The page just moved/acted under her: rects are stale, get off the
+    // furniture. Also feeds the "visitor is busy" clock that gates climbing.
+    function onUserActivity() {
+        lastUserAct = performance.now();
+        if (lifeState === 'perch') {
+            hopDown(lastUserAct);
+        } else if (lifeState === 'jump' && jumpArc && jumpArc.perch) {
+            jumpArc.perch = null; // retarget mid-air: land on the floor instead
+            jumpArc.toY = 0;
+        }
+    }
+
+    function onLifeResize() {
+        px = Math.min(Math.max(LIFE.EDGE_PAD, px), Math.max(LIFE.EDGE_PAD, window.innerWidth - spriteSize() - LIFE.EDGE_PAD));
+        floorProbeAt = -1;
+    }
+
+    function lifeAllowed() {
+        return mounted && !prefersReduced();
+    }
+
+    function startLife() {
+        if (alive || !lifeAllowed() || !root) return;
+        alive = true;
+        px = window.innerWidth < 900 ? 12 : 20;
+        py = 0;
+        dir = 1;
+        lastUserAct = performance.now();
+        nextThinkAt = performance.now() + 2500;
+        lifeLastTs = 0;
+        floorProbeAt = -1;
+        probeFloor(0);
+        root.classList.add('cg-alive');
+        setLifeState('stand');
+        applyLifeTransform();
+        lifeHandlers.scroll = onUserActivity;
+        lifeHandlers.wheel = onUserActivity;
+        lifeHandlers.touchmove = onUserActivity;
+        lifeHandlers.keydown = onUserActivity;
+        lifeHandlers.resize = onLifeResize;
+        window.addEventListener('scroll', lifeHandlers.scroll, { passive: true });
+        window.addEventListener('wheel', lifeHandlers.wheel, { passive: true });
+        window.addEventListener('touchmove', lifeHandlers.touchmove, { passive: true });
+        window.addEventListener('keydown', lifeHandlers.keydown);
+        window.addEventListener('resize', lifeHandlers.resize);
+        lifeRaf = requestAnimationFrame(lifeTick);
+    }
+
+    function stopLife() {
+        if (!alive) return;
+        alive = false;
+        if (lifeRaf) cancelAnimationFrame(lifeRaf);
+        lifeRaf = null;
+        lifeTimers.forEach(id => clearTimeout(id));
+        lifeTimers.clear();
+        ['scroll', 'wheel', 'touchmove', 'keydown', 'resize'].forEach(k => {
+            if (lifeHandlers[k]) window.removeEventListener(k, lifeHandlers[k]);
+            delete lifeHandlers[k];
+        });
+        jumpArc = null;
+        if (perchEl) {
+            perchEl.classList.remove('cg-perch-squish', 'cg-perch-release');
+            perchEl = null;
+        }
+        if (root) {
+            py = 0; // never freeze mid-air
+            setLifeState('stand');
+            root.classList.remove('cg-walking', 'cg-jumping', 'cg-landing', 'cg-spinning');
+            applyLifeTransform();
+        }
+    }
+
+    function evaluateLife() {
+        if (lifeAllowed()) {
+            startLife();
+        } else {
+            stopLife();
+            // Back to the stylesheet's static dock (reduced motion / teardown).
+            if (root) {
+                root.classList.remove('cg-alive');
+                root.style.transform = '';
+            }
+        }
     }
 
     function unbindToggleButton() {
@@ -330,6 +827,7 @@ const CathodeGuide = (() => {
     // doesn't linger stale mid-session.
     function onLanguageChanged() {
         if (!bubbleEl || !bubbleEl.classList.contains('cg-show') || !currentSectionKey) return;
+        if (bubbleOwner === 'quip') { hideBubble(); return; } // quips are throwaway lines
         renderBubbleContent(currentSectionKey);
     }
 
@@ -350,16 +848,29 @@ const CathodeGuide = (() => {
 
         languageHandler = onLanguageChanged;
         window.addEventListener('languageChanged', languageHandler);
+
+        reducedHandler = evaluateLife;
+        if (mqReduced) {
+            if (mqReduced.addEventListener) mqReduced.addEventListener('change', reducedHandler);
+            else if (mqReduced.addListener) mqReduced.addListener(reducedHandler); // Safari <14
+        }
+        evaluateLife();
     }
 
     function destroy() {
         if (!isActive) return;
         isActive = false;
 
+        stopLife();
         clearTimers();
         if (sectionObserver) { sectionObserver.disconnect(); sectionObserver = null; }
         unbindToggleButton();
         if (languageHandler) { window.removeEventListener('languageChanged', languageHandler); languageHandler = null; }
+        if (reducedHandler && mqReduced) {
+            if (mqReduced.removeEventListener) mqReduced.removeEventListener('change', reducedHandler);
+            else if (mqReduced.removeListener) mqReduced.removeListener(reducedHandler);
+        }
+        reducedHandler = null;
         unmountRoot();
 
         mqMobile = null;


### PR DESCRIPTION
## Summary

Cathode evolves from a reactive guide into a living character with autonomous behavior. She now walks the viewport floor, climbs visible cards when idle, hops between timeline commits, and speaks in each theme's voice. Blip gains a touch companion mode for mobile/tablet users. Both characters are now fully theme-aware with per-theme dialogue and visual styling.

## Key Changes

**Cathode Guide (`cathode-guide.js` + `cathode-guide.css`)**
- **Life engine**: New autonomous animation layer that runs independently of section reactions
  - Walks the viewport floor at 46px/s with waddle bob animation
  - Flips facing direction (--cg-dir) based on movement
  - Spins and performs playful hops
  - After ~9s of visitor inactivity, climbs visible cards (`.project-card`, `.git-commit-marker`, `.now-card`, etc.)
  - Uses timeline commits as stepping stones, hopping between nearby markers
  - Hops back down the instant the page scrolls
  - Perched cards squish on landing via `.cg-perch-squish`/`.cg-perch-release` animations
  - Bubble opens toward the roomy side of screen (`.cg-bub-right` class)
  - Reduced motion keeps engine off; static dock position applies unchanged

- **Themed bubbles**: Each theme gets its own visual fiction and dialogue
  - **terminal**: Keeps the kit's phosphor window with `$ / >` prompts and typewriter reveal
  - **default**: Warm atelier card (DM Sans, cream paper, teal accents, fade-in lines)
  - **blueprint**: Hand-drawn annotation (Architects Daughter, dashed frame, blue paper, fade-in lines)
  - **retro90s**: Win95 window meets comic strip (Comic Sans, magenta drop shadow, navy title bar, fade-in lines)
  - Per-theme bar titles (e.g., "guide.sh" → "bonjour" → "PLAN A-00" → "welcome.htm")
  - Per-theme line prefixes (terminal keeps "$ / >", others use empty prefix)
  - Proportional-font themes use fade-in animation instead of ch-based typewriter (prevents mid-word crop)

- **Quips**: Short perched one-liners in the current theme's voice
  - Never talks over section bubbles
  - Auto-hides after 4.6s without closing someone else's bubble
  - Theme-specific copy from `cathodeGuide.quips.*` i18n keys

- **Z-index fix**: Raised from 9500 to 2147483000 (above switchers, tooltips, modals; below Blip cursor only)
- **Mobile visibility**: Now visible below 380px (shrinks to 46px instead of `display: none`)
- **Power-off behavior**: Drops to floor, clears perch state, stops wandering before sag animation

**Blip Cursor (`blip-cursor.js` + `blip-cursor.css`)**
- **Touch companion mode**: New run mode for coarse pointers (touch/pen)
  - Pops up above each tap (offset 10px right, 34px up from finger)
  - Follows drags with the same spring physics as cursor mode
  - Dozes after 9s of inactivity (sooner than cursor's 25s, since he's a guest not a pointer)
  - Fades out entirely after 22s without touch
  - Native touch cursor behavior untouched
  - Marked with `.bc-touch` and `.bc-away` classes

- **Viewport width gate removed**: Blip now runs on any fine-pointer viewport
  - Old >=900px check silently left legacy theme cursor on half-screen desktop windows
  - Now a mouse deserves Blip even in narrow windows

**i18n Updates (`en.json` + `fr.json`)**
- Added `cathodeGuide.themes.*` section with per-theme dialogue for all 7 sections × 4 themes
- Added `cathodeGuide.quips.*` section with per-

https://claude.ai/code/session_01QftqkFfwipNrD9fDmhheto