### PR TITLE
Fix Cathode face visibility on non-terminal themes

### DIFF
--- a/.claude/work/2026-07-11-130300-cathode-face-visibility.md
+++ b/.claude/work/2026-07-11-130300-cathode-face-visibility.md
@@ -1,0 +1,38 @@
+# Cathode face invisible on non-terminal themes
+
+**Status**: completed
+**Branch**: `claude/cathode-expressions-visibility-8ax2a8`
+**Started**: 2026-07-11 13:03
+
+## Task
+Cathode's face + expression animations are invisible ("black on black") on
+every theme except terminal. Only terminal shows her face/expressions.
+
+## Root cause
+The CRT screen (face + all idle expressions) is drawn with `fill="currentColor"`,
+coloured by the kit rule `#cathode-guide .cg-scr { color: var(--cg-ink) }`.
+But the per-theme *bubble skin* blocks re-theme `--cg-ink` for the speech
+bubble, and that same var also drives the screen phosphor:
+- terminal  `--cg-ink:#33ff00` green  -> face visible
+- default   `--cg-ink:#2c2825` dark   -> face dark-on-dark
+- retro90s  `--cg-ink:#111111` dark   -> face dark-on-dark
+- blueprint `--cg-ink:#dcf3ff` pale   -> dim
+The sprite is meant to be the mascot's constant (see CSS comment ~L657-664);
+only the bubble should reskin. Screen phosphor must be decoupled from bubble ink.
+
+## Files Being Modified
+- frontend/css/cathode-guide.css
+
+## Progress
+- [x] Locate cause (cg-scr color tied to themed --cg-ink)
+- [x] Add site-integration rule locking screen phosphor to bright green
+- [x] Verify each theme in browser (computed color + screenshot)
+      -> all 4 themes: .cg-scr color = rgb(51,255,0), face opacity 1,
+         screenshots confirm visible green eyes/mouth on default+retro90s
+- [x] Commit + push
+
+## Notes/Discoveries
+- Fix lives in the site-integration section (below the kit marker), no kit edit.
+- New rule: `#cathode-guide .cg-scr { color: var(--cg-phosphor, #33ff00); }`
+  wins over kit L23 by source order (same specificity); `--cg-phosphor` is a
+  hook for future per-theme tinting but defaults to the constant CRT green.

--- a/frontend/css/cathode-guide.css
+++ b/frontend/css/cathode-guide.css
@@ -798,6 +798,18 @@ body[data-theme="retro90s"] #cathode-guide .cg-bar::after {
 }
 body[data-theme="retro90s"] #cathode-guide .cg-body { padding: 6px 8px 7px; }
 
+/* ── Screen phosphor = mascot constant, not per-theme bubble ink ──────────
+   The per-theme --cg-ink above reskins ONLY the speech bubble (dark ink on
+   light paper for default/retro90s, pale ink on blueprint, etc.). The CRT
+   screen is part of the constant sprite: Cathode's face and every idle
+   expression are drawn in currentColor on the near-black screen glass. Left
+   on --cg-ink, any theme whose bubble ink is dark paints the face
+   dark-on-dark and it disappears — only terminal, whose ink is already
+   phosphor green, escaped. Lock the screen to a bright phosphor on every
+   theme so the face reads everywhere; --cg-phosphor stays a hook for future
+   per-theme tinting but defaults to the constant CRT green. */
+#cathode-guide .cg-scr { color: var(--cg-phosphor, #33ff00); }
+
 /* Proportional-face themes (all but terminal): fade lines in instead of
    the ch-typed reveal, and lift the ch clamp so nothing ever gets cropped
    mid-word. Terminal keeps the kit's typewriter + caret untouched. */


### PR DESCRIPTION
## Summary
Fixes an issue where Cathode's face and expression animations were invisible ("black on black") on all themes except terminal. The mascot sprite is now visible across all four themes with consistent bright green phosphor coloring.

## Root Cause
The CRT screen (containing Cathode's face and idle expressions) was styled with `fill="currentColor"`, which inherited the per-theme `--cg-ink` CSS variable. While this variable correctly reskins the speech bubble for each theme, it inadvertently made the screen phosphor dark on themes with dark ink colors (default, retro90s), rendering the face invisible against the near-black screen background.

## Changes Made
- **frontend/css/cathode-guide.css**: Added a site-integration rule that decouples the screen phosphor color from the per-theme bubble ink
  - New rule: `#cathode-guide .cg-scr { color: var(--cg-phosphor, #33ff00); }`
  - Locks the screen to bright green (#33ff00) on all themes via source order specificity
  - Introduces `--cg-phosphor` as a future hook for per-theme tinting while maintaining the constant CRT green default
  - Includes detailed comment explaining the separation of concerns between sprite (constant) and bubble (themed)

## Testing
Verified across all four themes:
- **terminal**: Face remains visible with green phosphor ✓
- **default**: Face now visible with green phosphor (was dark-on-dark) ✓
- **retro90s**: Face now visible with green phosphor (was dark-on-dark) ✓
- **blueprint**: Face visible with green phosphor ✓

All themes show computed color `rgb(51, 255, 0)` with full opacity on the screen element.

https://claude.ai/code/session_017kHpvmcmd9MtjatKhPYx6S