### PR TITLE
Fix Blip touch mode: align cursor tip exactly on tap point

### DIFF
--- a/.claude/work/2026-07-11-174500-blip-touch-tip-alignment.md
+++ b/.claude/work/2026-07-11-174500-blip-touch-tip-alignment.md
@@ -1,0 +1,25 @@
+# Blip touch mode: tip lands exactly on tap point
+
+**Status**: completed
+**Branch**: `claude/blip-cursor-alignment-puero2`
+**Started**: 2026-07-11 17:45
+
+## Task
+On touch devices Blip appeared offset from the tap point (+10px right, -34px up).
+User wants the cursor tip (Blip's top-left hotspot) exactly on the tap point,
+like a real cursor.
+
+## Files Being Modified
+- frontend/js/core/effects/blip-cursor.js
+- frontend/css/blip-cursor.css (comment only)
+
+## Progress
+- [x] Remove TOUCH_OFFSET_X / TOUCH_OFFSET_Y, target raw clientX/clientY in touch mode
+- [x] Update comments (JS header, onTouchPoint, CSS touch-companion note)
+- [x] Verified with Playwright iPhone 13 emulation: hotspot settles at exactly
+      the tap coordinates, screenshot confirms tip-on-dot alignment
+
+## Notes/Discoveries
+- The hotspot contract (SVG shifted by (-6s,-3s)) already makes the root origin
+  the cursor tip, so touch mode just needed the same raw coordinates cursor
+  mode uses. No CSS change required.

--- a/frontend/css/blip-cursor.css
+++ b/frontend/css/blip-cursor.css
@@ -50,8 +50,8 @@ html.bc-active,html.bc-active *{cursor:none!important}
   #blip-cursor:not(.bc-touch) { display: none !important; }
 }
 
-/* Touch companion: pops in above each tap (see onTouchPoint), then fades
-   out entirely once he's been snoozing long enough. */
+/* Touch companion: lands tip-on-tap like a real cursor (see onTouchPoint),
+   then fades out entirely once he's been snoozing long enough. */
 .bc.bc-touch { transition: opacity .45s ease; }
 .bc.bc-touch.bc-away { opacity: 0; }
 

--- a/frontend/js/core/effects/blip-cursor.js
+++ b/frontend/js/core/effects/blip-cursor.js
@@ -13,8 +13,9 @@
  * Two run modes, picked from the primary pointer type:
  * - 'cursor' (fine pointer): Blip replaces the mouse pointer, any viewport.
  * - 'touch'  (coarse pointer): no pointer to replace, so Blip becomes a tap
- *   companion — he pops up right above each tap, follows drags with the same
- *   spring, then dozes off and fades away until the next touch.
+ *   companion — he lands with his cursor tip exactly on each tap point (same
+ *   hotspot contract as cursor mode), follows drags with the same spring,
+ *   then dozes off and fades away until the next touch.
  */
 const BlipCursor = (() => {
     const THEMES = ['terminal', 'default', 'blueprint', 'retro90s'];
@@ -51,8 +52,6 @@ const BlipCursor = (() => {
     const SNOOZE_AFTER_MS = 25000;   // cursor mode: doze off after this idle time
     const TOUCH_SNOOZE_MS = 9000;    // touch mode: doze sooner (he's a guest, not a pointer)
     const TOUCH_AWAY_MS = 22000;     // touch mode: fade out entirely after this
-    const TOUCH_OFFSET_X = 10;       // px right of the finger, so it doesn't cover him
-    const TOUCH_OFFSET_Y = -34;      // px above the finger
 
     // Suiveur à ressort sous-amorti : Blip traîne derrière la souris, dépasse
     // légèrement la cible et se pose avec un petit rebond (ζ ≈ 0.62).
@@ -291,14 +290,16 @@ const BlipCursor = (() => {
         play('bc-click');
     }
 
-    // Touch mode: Blip pops up just above the finger. First appearance (or a
-    // return from bc-away) teleports him there instead of springing across
-    // the whole screen from wherever he faded out.
+    // Touch mode: Blip lands with his cursor tip exactly on the tap point,
+    // like a real pointer (the hotspot contract puts the tip at the root's
+    // origin). First appearance (or a return from bc-away) teleports him
+    // there instead of springing across the whole screen from wherever he
+    // faded out.
     function onTouchPoint(e) {
         if (e.pointerType && e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
         const wasHidden = !seenMove || away;
-        targetX = e.clientX + TOUCH_OFFSET_X;
-        targetY = e.clientY + TOUCH_OFFSET_Y;
+        targetX = e.clientX;
+        targetY = e.clientY;
         if (wasHidden) {
             curX = targetX;
             curY = targetY;
@@ -312,8 +313,8 @@ const BlipCursor = (() => {
     function onTouchDrag(e) {
         if (e.pointerType && e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
         if (!seenMove || away) return;
-        targetX = e.clientX + TOUCH_OFFSET_X;
-        targetY = e.clientY + TOUCH_OFFSET_Y;
+        targetX = e.clientX;
+        targetY = e.clientY;
         lastMoveAt = Date.now();
     }
 


### PR DESCRIPTION
## Summary
Fixes Blip cursor positioning in touch mode so the cursor tip lands exactly on the tap point, matching the behavior of a real pointer instead of appearing offset.

## Changes
- **Removed touch offset constants**: Deleted `TOUCH_OFFSET_X` (10px) and `TOUCH_OFFSET_Y` (-34px) that were causing the cursor to appear offset from the tap point
- **Updated touch event handlers**: Modified `onTouchPoint()` and `onTouchDrag()` to use raw `clientX`/`clientY` coordinates instead of applying offsets
- **Updated documentation**: Clarified in comments that Blip's cursor tip (hotspot) now lands exactly on the tap point in touch mode, leveraging the existing hotspot contract that positions the tip at the root element's origin
- **Updated CSS comment**: Refined the touch companion description to reflect tip-on-tap alignment behavior

## Implementation Details
The fix leverages the existing SVG hotspot contract (which shifts the SVG by -6s, -3s to make the root origin the cursor tip). Touch mode now uses the same coordinate system as cursor mode, eliminating the need for manual offsets. This was verified with Playwright iPhone 13 emulation testing, confirming the hotspot settles exactly at tap coordinates.

https://claude.ai/code/session_01RTtQetdnLGHPLQ3Lav49wj