### PR TITLE
content(now, timeline): humanize copy — remove AI writing tells

### DIFF
--- a/frontend/data/en/git-history.json
+++ b/frontend/data/en/git-history.json
@@ -73,7 +73,7 @@
         {
           "hash": "rmp2026",
           "date": "2026-06",
-          "message": "Full rebuild — React + Go, coded with AI",
+          "message": "Full rebuild in React + Go, coded with AI",
           "author": "Ride My Park",
           "details": {
             "title": "Technical rebuild",
@@ -169,7 +169,7 @@
         {
           "hash": "cba2026pa",
           "date": "2026-04",
-          "message": "Platform Architect mission — Platform & Agentic AI (6 months)",
+          "message": "Platform Architect mission: Platform & Agentic AI (6 months)",
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Platform Architect (Platform & Agentic AI)",
@@ -177,7 +177,7 @@
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "dateRange": "Apr 2026 → Sept 2026",
-            "description": "6-month mission (Apr. 2026 → Sept. 2026) alongside the Lead Front-End role. Designing the architecture and standards around agentic AI and building the internal platform (based on MnM): agentic workflows, plugin and skill sharing for product and tech teams. With Gabriel Desbouis (AI engineer), trained around a hundred people on LLMs — him on the theory, me on the hands-on side and day-to-day support.",
+            "description": "6-month mission (Apr. 2026 → Sept. 2026) alongside the Lead Front-End role. Designing the architecture and standards around agentic AI and building the internal platform (based on MnM): agentic workflows, plugin and skill sharing for product and tech teams. With Gabriel Desbouis (AI engineer), trained around a hundred people on LLMs: him on the theory, me on the hands-on side and day-to-day support.",
             "tags": ["Agentic AI", "Platform Engineering", "LLM & Training", "Developer Experience"]
           }
         }

--- a/frontend/data/en/now.json
+++ b/frontend/data/en/now.json
@@ -3,10 +3,10 @@
   "headerLabel": "WHERE I'M AT",
   "intro": "",
   "paragraph": [
-    { "text": "For a few months now I've been running a Platform Architect mission at CBA alongside the Lead Front-End role. I set the architecture and standards around agentic AI, and I'm building the internal platform that will carry it all — a solution built on " },
+    { "text": "For a few months now I've been running a Platform Architect mission at CBA alongside the Lead Front-End role. I set the architecture and standards around agentic AI, and I'm building the internal platform that will carry it all. A solution built on " },
     { "link": { "text": "MnM", "url": "https://github.com/AlphaLuppi/mnm" } },
     { "text": " : composing agentic workflows, sharing plugins and skills, everything to equip the product and tech teams. I'm not doing this solo: with " },
     { "link": { "text": "Gabriel Desbouis", "url": "https://fr.linkedin.com/in/gabriel-desbouis" } },
-    { "text": ", an AI engineer, we've trained around a hundred people on LLMs — him on the theory, me on the hands-on side and day-to-day support — and it's still going. Gabriel also builds, on top of the platform, a whole catalogue of custom tools, from simple agents to more advanced agentic ones. I'm also wrapping up the RideMyPark rebuild: the old WordPress site rebuilt from scratch in React + Go, coded end to end with AI. A rewrite I'd been putting off for four years, done in a month. No freelance availability right now, my hands are already full." }
+    { "text": ", an AI engineer, we've trained around a hundred people on LLMs: him on the theory, me on the hands-on side and day-to-day support. And it's still going. Gabriel also builds custom tools on top of the platform, from simple agents to more advanced agentic ones. I'm also wrapping up the RideMyPark rebuild: the old WordPress site rebuilt from scratch in React + Go, coded end to end with AI. A rewrite I'd been putting off for four years, done in a month. No freelance availability right now, my hands are already full." }
   ]
 }

--- a/frontend/data/fr/git-history.json
+++ b/frontend/data/fr/git-history.json
@@ -73,7 +73,7 @@
         {
           "hash": "rmp2026",
           "date": "2026-06",
-          "message": "Refonte complète — React + Go, codée avec l'IA",
+          "message": "Refonte complète en React + Go, codée avec l'IA",
           "author": "Ride My Park",
           "details": {
             "title": "Refonte technique",
@@ -169,7 +169,7 @@
         {
           "hash": "cba2026pa",
           "date": "2026-04",
-          "message": "Mission Platform Architect — Plateforme & IA Agentique (6 mois)",
+          "message": "Mission Platform Architect : Plateforme & IA Agentique (6 mois)",
           "author": "CBA Informatique Liberale",
           "details": {
             "title": "Platform Architect (Plateforme & IA Agentique)",
@@ -177,7 +177,7 @@
             "company": "CBA Informatique Liberale",
             "location": "Avignon, France",
             "dateRange": "Avr 2026 → Sept 2026",
-            "description": "Mission de 6 mois (avr. 2026 → sept. 2026) menée en parallèle du Lead Front-End. Conception de l'architecture et des standards autour de l'IA agentique, et construction de la plateforme interne (basée sur MnM) : workflows agentiques, partage de plugins et de skills pour les équipes produit et tech. Avec Gabriel Desbouis (ingénieur IA), formation d'une centaine de personnes aux LLM — lui la théorie, moi la pratique et l'accompagnement au quotidien.",
+            "description": "Mission de 6 mois (avr. 2026 → sept. 2026) menée en parallèle du Lead Front-End. Conception de l'architecture et des standards autour de l'IA agentique, et construction de la plateforme interne (basée sur MnM) : workflows agentiques, partage de plugins et de skills pour les équipes produit et tech. Avec Gabriel Desbouis (ingénieur IA), formation d'une centaine de personnes aux LLM : lui la théorie, moi la pratique et l'accompagnement au quotidien.",
             "tags": ["IA Agentique", "Platform Engineering", "LLM & Formation", "Developer Experience"]
           }
         }

--- a/frontend/data/fr/now.json
+++ b/frontend/data/fr/now.json
@@ -3,10 +3,10 @@
   "headerLabel": "OÙ J'EN SUIS",
   "intro": "",
   "paragraph": [
-    { "text": "Ça fait quelques mois que je mène, en parallèle du Lead Front-End, une mission de Platform Architect chez CBA. J'y définis l'archi et les standards autour de l'IA agentique, et je construis la plateforme interne qui va porter tout ça — une solution basée sur " },
+    { "text": "Ça fait quelques mois que je mène, en parallèle du Lead Front-End, une mission de Platform Architect chez CBA. J'y définis l'archi et les standards autour de l'IA agentique, et je construis la plateforme interne qui va porter tout ça. Une solution basée sur " },
     { "link": { "text": "MnM", "url": "https://github.com/AlphaLuppi/mnm" } },
     { "text": " : création de workflows agentiques, partage de plugins et de skills, de quoi outiller les équipes produit et tech. Je ne fais pas ça tout seul : avec " },
     { "link": { "text": "Gabriel Desbouis", "url": "https://fr.linkedin.com/in/gabriel-desbouis" } },
-    { "text": ", ingénieur IA, on a formé une centaine de personnes aux LLM — lui sur la théorie, moi sur la pratique et l'accompagnement au quotidien — et le chantier continue. Gabriel développe aussi, par-dessus la plateforme, tout un catalogue d'outils sur mesure, du simple agent à de vrais outils agentiques plus poussés. En ce moment je termine aussi la refonte de RideMyPark : l'ancien site WordPress repart de zéro en React + Go, codé de bout en bout avec l'IA. Une refonte que je repoussais depuis quatre ans, bouclée en un mois. Pas de dispo freelance en ce moment, j'ai déjà les mains bien pleines." }
+    { "text": ", ingénieur IA, on a formé une centaine de personnes aux LLM : lui sur la théorie, moi sur la pratique et l'accompagnement au quotidien. Et le chantier continue. Gabriel développe aussi, par-dessus la plateforme, des outils sur mesure, du simple agent à de vrais outils agentiques plus poussés. En ce moment je termine aussi la refonte de RideMyPark : l'ancien site WordPress repart de zéro en React + Go, codé de bout en bout avec l'IA. Une refonte que je repoussais depuis quatre ans, bouclée en un mois. Pas de dispo freelance en ce moment, j'ai déjà les mains bien pleines." }
   ]
 }


### PR DESCRIPTION
## Résumé

Passe d'écriture sur les textes de juillet 2026 (section Now + timeline) pour retirer les marqueurs d'écriture IA, avec le skill [humanizer](https://github.com/blader/humanizer) exécuté par un sous-agent. Le sens, les faits, les liens et la structure JSON sont inchangés.

Fichiers modifiés :
- `frontend/data/fr/now.json` · `frontend/data/en/now.json`
- `frontend/data/fr/git-history.json` · `frontend/data/en/git-history.json`

## Changements

- **Tirets cadratins retirés** partout (remplacés par des points, deux-points, ou « en »/« in » selon le contexte) — dans le paragraphe Now (FR/EN) et dans les entrées timeline `cba2026pa` et `rmp2026`.
- **Tournures gonflées allégées** : « tout un catalogue d'outils sur mesure » → « des outils sur mesure » ; « a whole catalogue of custom tools » → « custom tools ».
- Ton conservé (première personne, direct, sans jargon), liens inline **MnM** et **Gabriel Desbouis** intacts (texte + URL), tous les faits préservés.
- Aucune autre entrée de la timeline ni aucun `tag`/`dateRange` touché.

## Tests

- JSON validé sur les 4 fichiers ✅
- Rendu vérifié dans le navigateur (Chromium/Playwright) : liens intacts, plus de tiret cadratin dans le Now, pas d'erreur console liée ✅


---
_Generated by [Claude Code](https://claude.ai/code/session_01Viv3PiiMzkSDgHSMXBgt2m)_