### PR TITLE
fix(timeline): stop the memory-leak reload + slower stepping-stone cathode hop

### DIFF
--- a/frontend/js/core/effects/cathode-guide.js
+++ b/frontend/js/core/effects/cathode-guide.js
@@ -577,10 +577,22 @@ const CathodeGuide = (() => {
 
     function startJump(toX, toY, perch, now) {
         const dist = Math.hypot(toX - px, toY - py);
+        // Timeline commit markers are stepping stones over water. When she's
+        // hopping onto one (the first climb) or between them (stone to stone),
+        // stretch the leap: slower, with a taller arc, so it reads as a
+        // careful hop with a real hang at the apex instead of a quick skip.
+        // Every other perch (cards, CTAs) keeps the snappy default hop.
+        const steppingStone = !!(perch && perch.classList &&
+            perch.classList.contains('git-commit-marker'));
+        const dur = steppingStone
+            ? Math.min(1400, 680 + dist * 0.85)
+            : Math.min(950, 420 + dist * 0.55);
+        const peak = steppingStone
+            ? 70 + Math.min(120, dist * 0.3)
+            : 36 + Math.min(90, dist * 0.22);
         jumpArc = {
             fromX: px, fromY: py, toX, toY, perch: perch || null,
-            start: now, dur: Math.min(950, 420 + dist * 0.55),
-            peak: 36 + Math.min(90, dist * 0.22)
+            start: now, dur, peak
         };
         if (Math.abs(toX - px) > 4) dir = toX >= px ? 1 : -1;
         setLifeState('jump');

--- a/frontend/js/git-timeline.js
+++ b/frontend/js/git-timeline.js
@@ -15,6 +15,12 @@ const GitTimeline = (() => {
     let overlay = null;
     let activeCommit = null;
     let scrollContainer = null;
+    // Guards listeners attached to persistent objects (window/document/the
+    // scroll container). render() re-runs on every resize, so without this
+    // flag those listeners would stack on each render — and because the
+    // resize handler itself calls render(), the count would compound on
+    // every resize until the tab runs out of memory and reloads.
+    let globalListenersBound = false;
 
     // ═══════════════════════════════════════════════════════════════
     // CONFIGURATION
@@ -571,7 +577,14 @@ const GitTimeline = (() => {
     // ═══════════════════════════════════════════════════════════════
 
     /**
-     * Set up all event listeners
+     * Set up per-render event listeners.
+     *
+     * These bind to nodes that render() recreates every time (the commit
+     * markers and the overlay), so re-binding here is correct: the previous
+     * nodes are discarded with the old innerHTML and their listeners are
+     * garbage-collected along with them. Listeners on persistent objects
+     * (window/document/scroll container) must NOT live here — see
+     * setupGlobalListeners().
      */
     function setupEvents() {
         // Commit marker hover/click
@@ -592,26 +605,43 @@ const GitTimeline = (() => {
             });
         });
 
-        // Overlay hover
+        // Overlay hover (overlay is recreated by createOverlay() each render,
+        // and the old one is removed, so this does not accumulate)
         if (overlay) {
             overlay.addEventListener('mouseleave', hideOverlay);
         }
 
-        // Click outside
+        // Listeners on window/document/scroll container — bound exactly once
+        setupGlobalListeners();
+    }
+
+    /**
+     * Set up listeners on persistent objects (window, document, the scroll
+     * container). These survive re-renders, so they are bound a single time.
+     * Binding them per render() would stack duplicates and, via the resize
+     * handler that re-invokes render(), compound on every resize — the memory
+     * leak that made the page lag and eventually reload.
+     */
+    function setupGlobalListeners() {
+        if (globalListenersBound) return;
+        globalListenersBound = true;
+
+        // Click outside → hide overlay
         document.addEventListener('click', (e) => {
             if (!e.target.closest('.git-commit-marker') && !e.target.closest('.git-timeline-overlay')) {
                 hideOverlay();
             }
         });
 
-        // Update overlay position on scroll
+        // Update overlay position on scroll (reads the module-scoped
+        // scrollContainer / overlay / activeCommit at event time)
         scrollContainer?.addEventListener('scroll', () => {
             if (activeCommit && overlay?.classList.contains('active')) {
                 showOverlay(activeCommit);
             }
         });
 
-        // Scroll-jacking for horizontal scroll
+        // Scroll-jacking for horizontal scroll + resize re-render
         setupScrollJacking();
     }
 


### PR DESCRIPTION
Two related timeline changes.

---

## 1. `fix(git-timeline)` — stop the memory leak that made the page lag and reload

### Problem

During a demo, the longer a visitor stayed on the page, the more it lagged, until the browser eventually reloaded the tab. That's the classic signature of a compounding memory leak (out-of-memory → tab reload), not a captured JS error — which is why PostHog error tracking showed nothing relevant.

### Root cause

`frontend/js/git-timeline.js` re-attached listeners on **persistent** objects inside `render()`, and never removed them:

- `window` `wheel` (scroll-jacking) — `setupScrollJacking()`
- `window` `resize` — which itself calls `render()` again
- `document` `click` (click-outside to close the overlay)
- scroll-container `scroll` (keep the overlay glued to its commit)

Because the `resize` handler re-invokes `render()`, every resize event **doubled** the number of listeners *and* the number of full timeline re-renders:

```
renders:         1 → 2 → 4 → 8 → 16 → 32 → 64
wheel listeners: 1 → 2 → 3 → 5 →  9 → 17 → 33 → 65
```

On mobile this ignites on its own: the viewport `resize` event fires constantly as the address bar shows/hides during scrolling. Within seconds you reach thousands of stacked listeners and full DOM rebuilds → OOM → reload.

### Fix

Split the two kinds of listeners:

- **Per-render** (`setupEvents`): commit markers + overlay. `render()` recreates these nodes every pass and discards the old ones, so re-binding is correct and the old listeners are GC'd with their nodes.
- **Global** (`setupGlobalListeners`): `window`/`document`/scroll-container listeners, now guarded by a `globalListenersBound` flag so they bind **exactly once**.

The resize-driven `render()` still runs (to recalculate `yearWidth`), but exactly once per resize now.

### Verification

Reproduced and fixed in headless Chromium by counting `window` listener registrations and `render()` calls while dispatching 6 `resize` events:

| | Before | After |
|---|---|---|
| `resize` listeners | 67 | 4 (flat) |
| `wheel` listeners | 65 | 2 (flat) |
| total renders | 64 (exponential) | 7 (one per resize) |

The timeline still renders correctly after the change (9 desktop markers + 9 mobile commits, SVG graph, year axis, NOW marker — no GitTimeline console errors).

---

## 2. `feat(cathode-guide)` — slower, higher hop across the timeline stepping stones

When the cathode mascot climbs onto a timeline commit marker, or hops between markers, the leap now uses a longer duration and a taller arc, so it reads like carefully jumping from stone to stone over water rather than a quick skip. The stepping-stone timing is triggered by the target perch's `.git-commit-marker` class; every other perch (cards, CTAs) keeps the snappy default hop.

`startJump()` in `frontend/js/core/effects/cathode-guide.js`:

- **duration**: `Math.min(1400, 680 + dist*0.85)` for stone hops vs `Math.min(950, 420 + dist*0.55)` default
- **arc peak**: `70 + Math.min(120, dist*0.3)` for stone hops vs `36 + Math.min(90, dist*0.22)` default

### Verification

Observed live in headless Chromium (let the mascot idle-climb onto the timeline and hop):

| Jump type | Duration |
|---|---|
| marker → marker (stepping stone) | ~950–1090 ms, higher apex |
| regular hop (non-marker) | ~600 ms |

No console errors; the mascot climbs the timeline and hops from marker to marker as intended.

---

## Scope

Two files: `frontend/js/git-timeline.js`, `frontend/js/core/effects/cathode-guide.js`. No visual change to the timeline layout itself; the mascot's stepping-stone hop is the only intentional feel change.
