### PR TITLE
Fix Cathode floating too high on the FPS theme

### DIFF
--- a/.claude/work/2026-07-14-171200-fps-cathode-floor-height.md
+++ b/.claude/work/2026-07-14-171200-fps-cathode-floor-height.md
@@ -1,0 +1,35 @@
+# FPS theme: Cathode floor height fix
+
+**Status**: completed
+**Branch**: `claude/cathode-fps-arena-height-nx0isu`
+**Started**: 2026-07-14 17:12
+
+## Task
+Cathode (the CRT mascot) sat visibly higher on the FPS arena theme than on
+every other theme, so her jumps/climbs also landed higher — reported by the
+user as "Cathode sur le theme FPS arena est + haut que sur les autres theme
+et du coup quand il saute quelque part il est + haut aussi".
+
+## Files Being Modified
+- frontend/themes/fps/fps.css
+- frontend/js/core/effects/cathode-guide.js
+
+## Progress
+- [x] Found root cause: `fps.css` unconditionally set `#cathode-guide { bottom: 64px }`
+      on desktop, fighting the life engine's `bottom:0` + JS-transform positioning
+      (the same system that already handles retro90s's fixed status bar via
+      `probeFloor()`). The JS still computed positions assuming a plain 20px
+      floor, so the CSS silently added an *extra* 64px on top.
+- [x] Scoped the CSS override to `:not(.cg-alive)` (static dock fallback only:
+      reduced motion / pre-mount).
+- [x] Extended `probeFloor()` to also read `#fps-telemetry`'s real height
+      (mirrors the existing `.retro-status-bar` handling), so the life engine
+      clears the fps telemetry bar by exactly its height + 6px buffer instead
+      of a flat 64px guess.
+- [x] Verified via Playwright screenshots + DOM measurements: fps floor gap is
+      now 37px (telemetry bar height + 6) vs. the old 84px (64 + 20), while
+      terminal/blueprint/retro90s/default are byte-for-byte unchanged.
+
+## Notes/Discoveries
+- No other theme had this bug — retro90s already used the correct
+  `probeFloor()` pattern instead of a CSS `bottom` override.

--- a/frontend/js/core/effects/cathode-guide.js
+++ b/frontend/js/core/effects/cathode-guide.js
@@ -537,12 +537,13 @@ const CathodeGuide = (() => {
     }
 
     // The floor line: the old docked insets (20px desktop / 12px mobile),
-    // raised above any fixed bottom bar a theme installs (retro90s status bar).
+    // raised above any fixed bottom bar a theme installs (retro90s status bar,
+    // fps telemetry bar).
     function probeFloor(now) {
         if (now - floorProbeAt < 1000 && floorProbeAt >= 0) return;
         floorProbeAt = now;
         let base = window.innerWidth < 900 ? 12 : 20;
-        const bar = document.querySelector('.retro-status-bar');
+        const bar = document.querySelector('.retro-status-bar, #fps-telemetry');
         if (bar && bar.offsetHeight) base = Math.max(base, bar.offsetHeight + 6);
         floorBase = base;
     }

--- a/frontend/themes/fps/fps.css
+++ b/frontend/themes/fps/fps.css
@@ -495,7 +495,13 @@ body[data-theme="fps"] #cathode-guide .cg-line::after { display: none; }
 @media (min-width: 900px) {
   /* Keep her clearly in front of the content plates (she was reading as stuck
      behind the NOW/WORK cards) but under the crosshair + fixed telemetry bar. */
-  body[data-theme="fps"] #cathode-guide { z-index: 47; bottom: 64px; }
+  body[data-theme="fps"] #cathode-guide { z-index: 47; }
+  /* The 64px floor lift is only for the static dock (reduced motion / before
+     the life engine mounts). Once cg-alive takes over, the engine already
+     clears the telemetry bar itself (probeFloor() reads #fps-telemetry's
+     height) - overriding bottom here too would double-apply the lift and
+     make every stand/walk/jump render 64px higher than on every other theme. */
+  body[data-theme="fps"] #cathode-guide:not(.cg-alive) { bottom: 64px; }
 }
 
 /* ───────── boot-strip ribbon (top hint bar) ─────────


### PR DESCRIPTION
## Summary
- Cathode (the CRT mascot) sat noticeably higher on the FPS arena theme than on every other theme, so her jumps/climbs also landed higher than elsewhere.
- Root cause: `fps.css` unconditionally set `#cathode-guide { bottom: 64px }` on desktop, fighting the life engine's `bottom:0` + JS-transform positioning system (the same mechanism that already clears retro90s's fixed status bar via `probeFloor()`). The JS still computed positions assuming a plain 20px floor, so the CSS silently stacked an extra 64px on top of every stand/walk/jump/climb.
- Fix: scope the CSS override to the static dock fallback only (`:not(.cg-alive)` — reduced motion / pre-mount), and extend `probeFloor()` to read `#fps-telemetry`'s real height, mirroring the existing `.retro-status-bar` handling for retro90s.

## Test plan
- [x] Verified via Playwright: fps floor gap is now 37px (telemetry bar height + 6px buffer) vs. the old 84px (64 + 20 stacked)
- [x] Confirmed terminal/blueprint/retro90s/default themes are byte-for-byte unchanged (same transform values as before)
- [x] Checked mobile viewport (390×844) — consistent ~35px floor gap
- [x] No console errors on any theme
- [x] Visual before/after screenshots confirm Cathode now docks snugly above the telemetry bar instead of floating with an oversized gap


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCVHyR3YvBPZ6tAQYcvjJz)_