### PR TITLE
fix(fps): restore palette icon on theme switcher, fix dropdown z-index

### DIFF
--- a/frontend/themes/fps/fps.css
+++ b/frontend/themes/fps/fps.css
@@ -63,8 +63,11 @@ body[data-theme="fps"] .hero-annotation { display: none !important; }
     linear-gradient(180deg, rgba(255,255,255,.14) 0%, rgba(255,255,255,0) 20%),
     linear-gradient(0deg, rgba(14,22,34,.26) 0%, rgba(14,22,34,0) 14%); }
 
-/* Content rides above the scene. */
-body[data-theme="fps"] #main-content { position: relative; z-index: 1; }
+/* Content rides above the scene. Sits above the injected HUD chrome that's
+   fixed to <body> (rail/side-panel/telemetry) so the header's dropdowns
+   (theme/language switcher) never render underneath them — but stays below
+   the cathode guide/crosshair/hit-fx/boot ribbon, which must stay topmost. */
+body[data-theme="fps"] #main-content { position: relative; z-index: 46; }
 /* Room for the fixed rail (left) and telemetry (bottom). The telemetry bar is
    opaque, so content must clear it fully or the two overlap at the fold. */
 body[data-theme="fps"] main#main-content { padding-left: 64px; padding-bottom: 56px; }
@@ -585,14 +588,6 @@ body[data-theme="fps"] .fps-eyebrow {
 #fps-badge .fps-badge-shield { width: 22px; height: 22px; color: var(--gold); flex: 0 0 auto; }
 #fps-badge .fps-badge-shield svg { width: 100%; height: 100%; }
 @media (max-width: 1023px) { #fps-badge { display: none; } }
-
-/* Theme + language chips: fold the loud default palette emoji into a mono HUD
-   label so the top-right zone stays tactical (switcher still fully usable). */
-body[data-theme="fps"] .theme-switcher-toggle { position: relative; width: auto; min-width: 0; padding: .3rem .55rem; font-size: 0; line-height: 1; }
-body[data-theme="fps"] .theme-switcher-toggle::after {
-  content: "\25E7 HUD"; font-size: .62rem; font-family: var(--mono); letter-spacing: .12em; color: var(--fg-dim);
-}
-body[data-theme="fps"] .theme-switcher-toggle:hover::after { color: #fff; }
 
 /* ───────── Cathode: retint the green terminal CRT to fps blue-steel ─────────
    The guide sprite's phosphor screen + bubble use the kit's --cg-* vars (green


### PR DESCRIPTION
## Summary
- Removed the fps theme's "⧧ HUD" text label on the theme switcher toggle; it now shows the same 🎨 palette icon as every other theme.
- Fixed the theme/language switcher dropdowns rendering **behind** the fps HUD chrome (profile card, contacts panel). `#main-content` only had `z-index: 1`, while the HUD panels are injected as fixed siblings of `<body>` at `z-index: 35-47` (side panel, telemetry, rail, cathode guide). Since `.header` (and its dropdowns) live inside `#main-content`, they were trapped in that lower stacking context no matter their own `z-index`. Raised `#main-content` to `z-index: 46` — above the HUD panels/rail/telemetry, still below the cathode guide, crosshair, hit-fx and boot ribbon.

## Test plan
- [x] Verified in a headless browser (Playwright) on `?theme=fps`: toggle shows the 🎨 icon, opening it now renders the dropdown above the profile/contacts panel instead of behind it.
- [x] Checked desktop (1400×900) and mobile (390×844) viewports for the fps theme — no layout regressions, cathode guide mascot still layers correctly above content cards.
- [x] Sanity-checked the theme switcher on `default`, `terminal`, `blueprint`, `retro90s` — untouched, still working.
- [x] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhqgauVzJ8ZemuX1PgQx8p)_