### PR TITLE
fix(blip-cursor): remove spring-back overshoot when following the pointer

### DIFF
--- a/.claude/work/2026-07-14-171337-blip-cursor-springback.md
+++ b/.claude/work/2026-07-14-171337-blip-cursor-springback.md
@@ -1,0 +1,37 @@
+# Blip cursor: kill the spring-back overshoot
+
+**Status**: completed
+**Branch**: `claude/blip-cursor-springback-9d4llk`
+**Started**: 2026-07-14 17:13
+
+## Task
+The cursor follower (Blip) overshot the target and bounced back ("ressort" /
+"retour arrière") when following the mouse, making it hard to aim at things.
+
+## Files Being Modified
+- frontend/js/core/effects/blip-cursor.js (comments only + 2 spring constants)
+
+## Progress
+- [x] Diagnose: the follower is an intentionally under-damped spring (ζ ≈ 0.62),
+      which by definition overshoots and bounces. Confirmed no CSS transition on
+      `transform` adds extra springiness — all motion is the JS integrator in
+      `tick()`.
+- [x] Retune to quasi-critical damping: SPRING_K 190→520, SPRING_C 17→48
+      (ζ ≈ 1.05). Stiffness raised to keep the same trailing lag during motion
+      (lag ≈ (C/K)·speed, ~0.09s, unchanged); only the settle changes.
+- [x] Update comments (constants block + body-language "tremblé de pose").
+- [x] Numeric check of the exact symplectic-Euler integrator: overshoot
+      6px→0px at 48–144fps; trailing lag ~58px→~60px @800px/s (unchanged).
+- [x] Browser E2E (Playwright + preinstalled Chromium): cursor mode active,
+      flick-and-stop settles exactly on target with 0px overshoot, no console
+      errors. All 5 themes load clean; fps hard-snap path (+13px offset)
+      untouched.
+
+## Notes/Discoveries
+- Counterintuitive: pushing damping higher than ~ζ1.1 makes the 30fps MAX_DT
+  clamp frame numerically unstable, because the explicit velocity-damping term
+  `-vel*C*dt` needs C·dt < 2. C=48 gives C·dt=1.6 at the 1/30 clamp — safely
+  stable, with only a bounded ~2px transient on the rare post-refocus frame and
+  exactly 0 overshoot at every real refresh rate.
+- The FPS theme uses a separate hard-snap branch (`isFpsSnap()`), unaffected by
+  the spring constants.

--- a/frontend/js/core/effects/blip-cursor.js
+++ b/frontend/js/core/effects/blip-cursor.js
@@ -65,10 +65,15 @@ const BlipCursor = (() => {
     const TOUCH_SNOOZE_MS = 9000;    // touch mode: doze sooner (he's a guest, not a pointer)
     const TOUCH_AWAY_MS = 22000;     // touch mode: fade out entirely after this
 
-    // Suiveur à ressort sous-amorti : Blip traîne derrière la souris, dépasse
-    // légèrement la cible et se pose avec un petit rebond (ζ ≈ 0.62).
-    const SPRING_K = 190;          // raideur (s^-2)
-    const SPRING_C = 17;           // friction (s^-1)
+    // Suiveur à ressort en amortissement quasi critique : Blip traîne derrière
+    // la souris pendant le mouvement puis se pose SANS dépassement ni rebond
+    // (ζ ≈ 1.05). L'ancien réglage sous-amorti (ζ ≈ 0.62) dépassait la cible et
+    // faisait faire un « retour arrière » à la pointe — impossible de viser. La
+    // raideur est montée en compensation pour conserver le même retard de suivi
+    // en mouvement (retard ≈ (C/K)·vitesse, inchangé) : seule la pose change,
+    // elle arrive maintenant tout droit sur la cible.
+    const SPRING_K = 520;          // raideur (s^-2)
+    const SPRING_C = 48;           // friction (s^-1) — ζ = C/(2√K) ≈ 1.05
     const MAX_DT = 1 / 30;         // clamp du pas de temps (retour d'onglet, freeze)
     const SETTLE_DIST = 0.15;      // px — seuil de pose
     const SETTLE_VEL = 4;          // px/s
@@ -199,7 +204,8 @@ const BlipCursor = (() => {
     }
 
     // Il s'incline dans le sens du déplacement et s'étire le long de sa
-    // trajectoire (volume conservé) ; le tremblé de pose vient du ressort.
+    // trajectoire (volume conservé), puis revient au repos net dès qu'il se
+    // pose (plus de tremblé : le ressort est en amortissement quasi critique).
     function applyBodyLanguage() {
         if (!motionEl) return;
         const speed = Math.hypot(velX, velY);


### PR DESCRIPTION
## Problème

Quand Blip suit le curseur, il faisait un « ressort » / « retour arrière » : la pointe dépassait la cible puis revenait dessus en oscillant. Impossible de viser un élément proprement.

## Cause

Le suiveur est un ressort **volontairement sous-amorti** (`ζ ≈ 0.62`) dans `tick()`. Un amortissement < 1 dépasse la cible et rebondit **par définition** — c'est exactement le comportement décrit. (Vérifié : aucune `transition: transform` en CSS n'ajoute de rebond ; toute la dynamique vient de l'intégrateur JS.)

## Correctif

Passage en **amortissement quasi critique** (`ζ ≈ 1.05`) — le retour le plus rapide possible **sans aucun dépassement** :

| constante | avant | après |
|-----------|-------|-------|
| `SPRING_K` (raideur) | 190 | 520 |
| `SPRING_C` (friction) | 17 | 48 |
| `ζ = C/(2√K)` | 0.62 (rebondit) | 1.05 (ne dépasse pas) |

La raideur est montée en même temps que la friction pour **conserver le même retard de suivi pendant le mouvement** (`retard ≈ (C/K)·vitesse ≈ 0,09 s`, inchangé). Seule la **pose** change : Blip arrive maintenant tout droit sur la cible, sans dépassement ni tremblé. Le chemin *hard-snap* du thème `fps` n'est pas touché.

## Vérification

- **Modèle numérique** de l'intégrateur exact (symplectic Euler) : dépassement **6 px → 0 px** de 48 à 144 fps ; retard de suivi ~58 px → ~60 px @800 px/s (inchangé). Détail utile : monter l'amortissement au-delà de ~ζ1.1 rend l'image d'horloge à 30 fps (`MAX_DT`) instable car le terme `-vel·C·dt` exige `C·dt < 2` ; `C=48` donne `C·dt=1.6` au clamp — stable, avec seulement un transitoire borné ~2 px sur la rare frame post-refocus.
- **Test navigateur** (Playwright + Chromium préinstallé) : mode curseur actif, un flick-puis-arrêt se pose **exactement** sur la cible (`maxX=1000.00`, dépassement **0 px**), aucune erreur console. Les 5 thèmes (default, terminal, blueprint, retro90s, fps) se chargent sans erreur ; le décalage `+13 px` du snap `fps` est préservé.

## Fichiers

- `frontend/js/core/effects/blip-cursor.js` — 2 constantes de ressort + commentaires
- `.claude/work/2026-07-14-171337-blip-cursor-springback.md` — note de suivi

---
_Generated by [Claude Code](https://claude.ai/code/session_0113bJGMryXvEsgUcw7J6TWo)_