### PR TITLE
fix(cathode): spin no longer crops below the viewport bottom

### DIFF
--- a/.claude/work/2026-08-12-131700-cathode-spin-bottom-crop.md
+++ b/.claude/work/2026-08-12-131700-cathode-spin-bottom-crop.md
@@ -1,0 +1,46 @@
+# Cathode: self-spin cropped at the viewport bottom
+
+**Status**: completed
+**Branch**: `cursor/fix-cathode-spin-bottom-crop-b24e`
+**Started**: 2026-08-12 13:17
+
+## Task
+When Cathode does her full spin on herself (`cg-spinning` / `cg-life-spin`,
+triggered by the life engine's idle beats, perch victory spins, timeline
+far-bank spins, and the Blip meet/repair scenes), most of the sprite
+disappears below the bottom edge of the viewport mid-turn, then pops back
+as the spin completes. Reported for tomandrieu.com.
+
+## Files Being Modified
+- frontend/css/cathode-guide.css
+
+## Progress
+- [x] Found root cause: `cg-life-spin` runs on `.cg-sprite`, whose
+      transform-origin is `50% 88%` (the foot-level pivot meant for the
+      small standing lean). A 360° turn around a pivot ~9px above her feet
+      swings up to ~75px of sprite below the pivot, but the pivot only has
+      ~29px of room above the viewport bottom (20px floor gap + 9px), so
+      ~46px of the sprite gets hard-clipped at the viewport edge on desktop
+      (~38px mobile). `position: fixed` means no ancestor overflow rule can
+      help — the viewport edge itself is the clip.
+- [x] Fix: pivot the spin on her middle — `#cathode-guide.cg-spinning
+      .cg-sprite { transform-origin: 50% 50% }`, exactly parallel to the
+      existing `cg-tumbling` origin override right above it. Worst-case
+      rotated extent below her box is ~0.21 × sprite size (≈15px desktop,
+      ≈12px mobile), always inside the 12–20px floor gap once the kit's
+      mid-spin `scale(.9)` squash is counted; FPS's telemetry-bar floor
+      (~35px) absorbs its ±13px parallax too.
+- [x] Boundary frames are rotate(0)/rotate(1turn) with scaleX symmetric
+      about origin-x 50%, so the origin swap causes no visible jump when
+      the class toggles.
+- [x] Verified via Playwright (terminal + default themes, 1440×900 and
+      375×700): froze the animation at 131°–287° with negative
+      animation-delay — before: only a sliver of sprite visible at 180°;
+      after: fully visible at every phase. Rest pose byte-identical
+      before/after (rule only applies while `cg-spinning` is set). Also
+      recorded before/after videos of the natural spin; no console errors.
+
+## Notes/Discoveries
+- `cg-tumbling` already rotated about the middle — the spin was the only
+  rotation channel left on the foot pivot. Walking waddle (±1.7°) and the
+  standing lean (±14°) stay on `50% 88%` on purpose and fit the floor gap.

--- a/frontend/css/cathode-guide.css
+++ b/frontend/css/cathode-guide.css
@@ -404,6 +404,15 @@ body.loading #cathode-guide {
 /* Rolling bodies rotate about their middle, and cast no believable shadow */
 #cathode-guide.cg-tumbling .cg-sprite { transform-origin: 50% 50%; }
 #cathode-guide.cg-tumbling .cg-shadow { opacity: 0; }
+/* The self-spin pivots on her middle too. Around the default foot-level
+   lean origin (50% 88%) a full turn swings most of the sprite below the
+   floor line, and the fixed root is hard-clipped at the viewport's bottom
+   edge — she visibly lost her top half mid-spin. About her center the
+   rotated bounds stay inside the floor gap at every size (worst case
+   ≈ .21 × sprite below her box, less than the 12–20px floor inset once
+   the mid-spin squash is counted in). Boundary frames are rotate(0)/
+   rotate(1turn), so the origin swap itself never causes a visual jump. */
+#cathode-guide.cg-spinning .cg-sprite { transform-origin: 50% 50%; }
 
 /* Stroll waddle: a quick two-step bounce on the kit's hop wrapper. Declared
    after the kit's own .cg-hop rules so it wins while cg-walking is set. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When Cathode does her full spin on herself (`cg-spinning`, triggered by the life engine's idle beats, perch victory spins, the timeline far-bank spin, and the Blip meet/repair scenes), most of the sprite disappears below the bottom edge of the viewport mid-turn, then pops back as the spin completes.

## Root cause

`cg-life-spin` runs on `.cg-sprite`, whose transform-origin is **`50% 88%`** — the foot-level pivot meant for the small standing lean. A 360° turn around a pivot ~9px above her feet swings up to ~75px of sprite below that pivot, but the pivot only has ~29px of room above the viewport bottom (20px floor gap + 9px). Since `#cathode-guide` is `position: fixed`, everything past the viewport's bottom edge is hard-clipped — no ancestor `overflow` rule can help. Net effect: **~46px of the 74px sprite cropped on desktop** (~38px mobile) around the 150–225° stretch of every spin.

## Fix (one rule)

Pivot the spin on her middle, exactly parallel to the `cg-tumbling` origin override right above it:

```css
#cathode-guide.cg-spinning .cg-sprite { transform-origin: 50% 50%; }
```

Why this is safe:
- Worst-case rotated extent below her box with a center pivot is ~0.21 × sprite size (≈15px desktop / ≈12px mobile / ≈10px tiny) — always inside the 12–20px floor gap, with extra margin from the kit's mid-spin `scale(.9)` squash. FPS's telemetry-bar floor (~35px via `probeFloor()`) absorbs that theme's ±13px pointer parallax too.
- The spin's boundary frames are `rotate(0)` / `rotate(1turn)` and `scaleX` is symmetric about origin-x 50%, so the origin swap is invisible when the class toggles — no jump at spin start/end.
- Nothing else changes: the walking waddle (±1.7°) and the standing lean (±14°) deliberately keep the foot-level pivot, and they fit the floor gap.

## Before / after

Spin frozen at ~180° (desktop 1440×900, terminal theme) — before, only a sliver of her remains above the viewport edge; after, she's fully visible:

| Before | After |
|---|---|
| [Before: sprite almost fully cropped at 180°](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fbefore-desktop-180deg.png) | [After: sprite fully visible at 180°](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fafter-desktop-180deg.png) |
| [Before: sprite half cropped at 147°](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fbefore-desktop-147deg.png) | [After: sprite fully visible at 147°](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fafter-desktop-147deg.png) |

Mobile (375×700), same frozen frame:

| Before | After |
|---|---|
| [Before mobile: sprite cropped](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fbefore-mobile-180deg.png) | [After mobile: sprite fully visible](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fafter-mobile-180deg.png) |

Full natural spin (×2), recorded live:

**Before:**

[before-spin.mp4](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fbefore-spin.mp4)

**After:**

[after-spin.mp4](https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcathode-spin%2Fafter-spin.mp4)

## Testing

- Playwright headless Chromium against `python3 -m http.server 8000`, on the terminal + default themes at 1440×900 and 375×700.
- Froze `cg-life-spin` at five phases (131° → 287°) via negative `animation-delay` + `animation-play-state: paused`; screenshotted each phase before (origin reverted to `50% 88%` via injected override) and after (repo CSS). Every phase is fully visible after the fix.
- Resting pose captured before/after: pixel-identical (the rule only applies while `cg-spinning` is set), so floor walking, jumps, perching, tumbling and meet scenes are untouched.
- No console errors during any run.
- Work file added per the repo's agent-coordination convention (`.claude/work/2026-08-12-131700-cathode-spin-bottom-crop.md`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4094aa64-05b3-4576-a9fa-2022bc04b24e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4094aa64-05b3-4576-a9fa-2022bc04b24e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

