### PR TITLE
chore: bump CACHE_BUST so production picks up ca-ride article

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=builder /app/server .
 
 # Cache bust — changing this value invalidates the articles layer below.
 # Bump on deploys that need fresh articles without changing backend source.
-ARG CACHE_BUST=2026-04-25-ssr
+ARG CACHE_BUST=2026-08-13-ca-ride
 RUN echo "Articles cache bust: ${CACHE_BUST}"
 
 # Copy articles from the repo (ensures fresh articles on every build)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Production `https://api.tomandrieu.com/api/articles/ca-ride-telephone` still 404s after #82 because the backend image copies `blog/articles` at build time and Docker caches that layer.

This PR only bumps `ARG CACHE_BUST` in `backend/Dockerfile` from `2026-04-25-ssr` to `2026-08-13-ca-ride`, which invalidates the articles COPY layer on the next image build.

No article content changes. The article stays private.

Please merge so the next deploy includes the article.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-448e2868-a605-41ef-b93d-3168cf4ab62b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-448e2868-a605-41ef-b93d-3168cf4ab62b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

