### PR TITLE
Rewrite private ca-ride article as colliding worlds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=builder /app/server .
 
 # Cache bust — changing this value invalidates the articles layer below.
 # Bump on deploys that need fresh articles without changing backend source.
-ARG CACHE_BUST=2026-08-13-ca-ride
+ARG CACHE_BUST=2026-08-14-mondes
 RUN echo "Articles cache bust: ${CACHE_BUST}"
 
 # Copy articles from the repo (ensures fresh articles on every build)

--- a/blog/articles/ca-ride-telephone/index.en.md
+++ b/blog/articles/ca-ride-telephone/index.en.md
@@ -1,6 +1,6 @@
 ---
-title: "I shipped « Ça ride » from my phone"
-excerpt: "A migration in the car, a holiday I would have cancelled, then the maternity ward. How AI let me keep RideMyPark moving without choosing between the product and the people I live with."
+title: "When my worlds collide"
+excerpt: "The biggest rebuild of my career went out as my daughter was about to arrive."
 publishedAt: "2026-08-12"
 lang: en
 draft: false
@@ -10,36 +10,38 @@ passwordHash: "$2a$10$ETbH0aLpwd92h1XAxzRJjex87i/.iOQDYKPHAEU4LKkmZjJ153mX2"
 coverImage: "cover.png"
 ---
 
-On July 25, we packed the car and left for our holiday. My partner was 34 weeks pregnant, and RideMyPark was still running through my head. The migration from the old WordPress site to the new one had been ready for a while: the plan was written, the scripts were done, and all it really needed was a window when I could watch production closely. We moved our departure forward, so that window had effectively disappeared. I launched the migration anyway, just before we hit the road.
+On July 25 we packed the car. My partner was 34 weeks pregnant, and RideMyPark was in a state I had never managed to reach. The biggest rebuild and migration of my career, the one I had been dragging for five years, was ready to go out. Our daughter was due in the coming weeks. The two had no reason to line up, and yet it was the same month.
 
-## On the highway
+## Five years, then one month
 
-I wasn't the one watching the screens in the car. My partner was following the agents and the site's status from her phone: maintenance mode went up, came back down, and the new site went live. I asked her to open the mobile app and check that the spots still appeared and that nothing obvious was broken. For the most part, everything held up—except the reviews were missing. Under normal circumstances, that kind of irritating detail would have kept me at a computer for at least two hours while I investigated, patched, redeployed, and tested again.
+The migration from the old WordPress site to the new one had been ready for a while: the plan was written, the scripts were done, and all it really needed was a window to watch production. We moved our departure forward, so that window had basically disappeared, and I launched the migration anyway before we hit the road.
 
-Instead, I described the symptom to an agent. It fixed the issue, we tested again, and that was it. Nothing spectacular, but exactly the kind of small problem that would once have swallowed the start of the holiday—or made me hesitate to leave at all.
+I wasn't the one watching the screens in the car. My partner was, on her phone. She followed what the agents were saying and the state of the site: maintenance went up, it came down, the new site was live. I asked her to open the mobile app and check that the spots still showed and that nothing obvious was broken. For the most part it held, except the reviews were not coming back, the kind of annoying detail that would normally have stuck you to a computer for at least two hours to understand, patch, redeploy, and test again.
 
-## A week in the Pyrenees
+I described the symptom to an agent, it fixed it, we tested again, and it was fine. Before, that grain of sand would have eaten the start of the holiday, or talked me out of leaving at all.
 
-We were staying in a family house. There was a pool, there were people around, and I wasn't putting a laptop on the table to “just finish one thing.” I used my phone in the car, late at night when everyone was asleep, or in the quiet gaps between everything else. This wasn't a disguised workday. They were short windows: start a cloud session, review the result, put the phone away.
+Because in a normal world I would have cancelled. I was so close on this rebuild that production could not wait. Five years of never getting it finished, and then, with AI, it went through in a month. Once it is finally there, you do not put it off, even if everything on the other side is already speeding up.
 
-There is a real question here about whether that counts as switching off, and I want to write about it properly in another article rather than bury it in a footnote. What I can say is that, without AI, I probably would have cancelled this holiday. I was too close to finishing a redesign I had dragged behind me for five years without ever getting it over the line, and the release could not wait any longer. AI helped compress that redesign into a month, which meant I could still go—not disconnecting 100%, but perhaps 80%. That is infinitely better than staying home to finish the migration while everyone else is away.
+## A few days off, in the middle
 
-In one of those quiet gaps, I also let myself return to something I had postponed for years: sessions. Not a big public event, just a simple “let's meet at the spot” between riders, either right now or two weeks from now because people have jobs. The old WordPress setup never gave us solid ground for it. Now that the new site was live, I started by shaping the product with Claude Code—what are we actually trying to make, spontaneous or planned, who is it for, and where does V1 stop?—instead of asking AI to generate the whole feature in one shot. Within a day or two, we had settled on “Ça ride.” More importantly, I could work on it while the energy was there instead of waiting for some imaginary sprint after the holiday.
+We were in a family house in the Pyrenees, there was a pool, there were people around, and I was not putting a laptop on a table to “just finish one thing.” I took my phone out in the car, at night when everyone was asleep, in the leftover gaps of the day. Short windows: start an agent in the cloud, look at the result, put it away.
 
-## At the hospital, without turning it into a manifesto
+There is a real disconnect question here, and I will write about it in another article, because it deserves more than a parenthesis. What I can say here is that those days still happened. We had a holiday in the middle of all this. Not dropping everything 100%, more like unplugging around 80%, which is already much better than staying home to finish the migration while everyone else is away.
 
-Then nothing went to plan: contractions, the maternity ward, our daughter being born on August 2, and then the neonatal unit. Most of the time, we fed her, slept, and started over. I am not telling this story to frame “shipping from the hospital” as some kind of achievement. I worked when everyone else was asleep, in the same quiet windows when many people would doomscroll or put on a show. In those moments, I enjoy prototyping and moving RideMyPark forward. It is not morally better or worse; it is simply what I do.
+Before, work would have taken the whole week. This time it took the gaps, and the rest could stay a holiday.
 
-In the past, I would have felt guilty. I would have been anxious about choosing between my daughter and work—and however obvious the choice looks on paper, my brain does not always process it that neatly. Now I no longer have to make that choice in quite the same way. I can work for an hour across an entire day, split into ten tiny sessions, and the product moves as though I had spent a week at a computer, while I still care for my family, exercise, and stay present the rest of the time.
+## The other world
 
-Of course, it is less relaxing than dropping everything. But there are moments when fully dropping everything is not a luxury you have. AI gave me a middle ground that is far better for the people close to me than being the person who brings a laptop on holiday—or to the hospital—and never really joins them.
+Then nothing went as planned: contractions, the maternity ward, the birth on August 2, then the neonatal unit. Most of the time we feed, we sleep, we start over. I am not telling this to make it a performance. I do it when everyone is asleep, in the quiet moments, the same kind of windows where a lot of people doomscroll or put a show on. In those moments I enjoy prototyping and moving RideMyPark forward. That is just what I do.
 
-My colleagues tested the feature on staging. There was not a huge amount of feedback, so I released it to production with the feature enabled only for them at first, giving us a chance to see whether it held together before exposing it to everyone. I am still in the polish loop today—the timer for an upcoming session, for example, the kind of detail that changes how a product feels. I take their feedback from Discord, give it to Claude Code, iterate, and test again as I go.
+Before, I would have felt guilty. I would have been anxious about choosing between my daughter and work, and even if the choice looks obvious on paper, my brain does not always treat it that cleanly. Now I do not really have to choose in the same way. I can work an hour in a day, split into ten small pieces, and the product moves as if I had spent a week at a computer, while I take care of my family, exercise, and stay present the rest of the time.
 
-## What this changes for me
+It is less relaxing than dropping everything. But some moments you do not get the luxury of dropping everything, and AI let me find a middle ground that is much better for the people close to me than being the person who shows up with a computer and is not really there.
 
-Taken together, these steps are not a method anyone should copy. They are a series of moments when execution stopped requiring me to be tied to a desk.
+## After the fact
 
-The migration held while we were on the road, and the mobile bug was fixed without stealing the day. The holiday happened when I would otherwise have cancelled it, because a five-year redesign had finally been compressed into a month. The sessions feature took shape in the margins rather than inside an ideal schedule. And during the busiest period of all, I did not have to turn every spare hour into guilt: one fragmented hour across the day was enough to move the product forward without making it the center of everything.
+I finally got out a rebuild I could not finish, and my daughter was born right after. In the middle we still had some holiday days.
 
-In [Identity shift](https://tomandrieu.com/blog/identity-shift), I wrote that coding is no longer the hard part. I did not yet have this proof in my hands. Now I do: judgment can fit in a pocket, and execution no longer needs me to sacrifice the people around me in order to make progress.
+What made it tenable is that I no longer needed to be stuck at a desk for things to move. The migration held while we were on the road. The mobile bug got fixed without stealing the day. The holiday happened when I would have cancelled. And during the busiest stretch, I did not have to turn every spare hour into guilt.
+
+In [Identity shift](https://tomandrieu.com/blog/identity-shift), I wrote that coding is no longer the hard part. I did not have that proof in my hands yet. Now judgment fits in a pocket, and I can move RideMyPark forward without setting the rest of my life down next to it.

--- a/blog/articles/ca-ride-telephone/index.fr.md
+++ b/blog/articles/ca-ride-telephone/index.fr.md
@@ -1,6 +1,6 @@
 ---
-title: "J'ai shippé « Ça ride » depuis mon téléphone"
-excerpt: "Une migration en voiture, des vacances que j'aurais annulées, puis la maternité. Comment l'IA m'a permis d'avancer RideMyPark sans choisir entre le produit et les gens avec qui je vis."
+title: "Quand mes mondes s'entrechoquent"
+excerpt: "La plus grosse refonte de ma carrière est sortie au moment où ma fille arrivait."
 publishedAt: "2026-08-12"
 lang: fr
 draft: false
@@ -10,36 +10,38 @@ passwordHash: "$2a$10$ETbH0aLpwd92h1XAxzRJjex87i/.iOQDYKPHAEU4LKkmZjJ153mX2"
 coverImage: "cover.png"
 ---
 
-Le 25 juillet on charge la voiture pour partir en vacances. Ma partenaire est à 34 semaines, et moi j'ai encore RideMyPark dans la tête parce que la migration de l'ancien WordPress vers le nouveau site est prête depuis un moment : le plan est écrit, les scripts aussi, il ne manquait surtout qu'une fenêtre pour surveiller la mise en prod. On a avancé le départ, donc cette fenêtre n'existait plus vraiment, et j'ai lancé la migration quand même avant de prendre la route.
+Le 25 juillet on charge la voiture. Ma partenaire est à 34 semaines, et RideMyPark est dans un état que je n'avais jamais réussi à atteindre. La plus grosse refonte et migration de ma carrière, celle que je traîne depuis cinq ans, est prête à sortir. Notre fille arrive dans les semaines qui viennent. Les deux n'ont aucune raison de s'attendre, et pourtant c'est le même mois.
 
-## Sur l'autoroute
+## Cinq ans, puis un mois
 
-Dans la voiture ce n'est pas moi qui regarde les écrans, c'est ma partenaire sur son téléphone. Elle suit ce que disent les agents et l'état du site : la maintenance se met en place, elle se termine, le nouveau site est en ligne. Je lui demande d'ouvrir l'app mobile pour vérifier que les spots s'affichent encore et que rien d'évident n'est cassé. Globalement ça tient, sauf les avis qui ne remontent pas — le genre de détail agaçant qui, en temps normal, t'aurait collé au moins deux heures devant un ordi pour comprendre, patcher, redéployer et retester.
+La migration de l'ancien WordPress vers le nouveau site est calée depuis un moment : le plan est écrit, les scripts aussi, il ne manquait surtout qu'une fenêtre pour surveiller la mise en prod. On a avancé le départ, donc cette fenêtre n'existait plus vraiment, et j'ai lancé la migration quand même avant de prendre la route.
 
-Là je décris le symptôme à un agent, il corrige, on reteste, et c'est bon. Ce n'est pas spectaculaire, mais c'est exactement le genre de grain de sable qui, avant, aurait mangé le début des vacances ou m'aurait fait hésiter à partir du tout.
+Dans la voiture ce n'est pas moi qui regarde les écrans, c'est ma partenaire sur son téléphone. Elle suit ce que disent les agents et l'état du site : la maintenance se met en place, elle se termine, le nouveau site est en ligne. Je lui demande d'ouvrir l'app mobile pour vérifier que les spots s'affichent encore et que rien d'évident n'est cassé. Globalement ça tient, sauf les avis qui ne remontent pas, le genre de détail agaçant qui, en temps normal, t'aurait collé au moins deux heures devant un ordi pour comprendre, patcher, redéployer et retester.
 
-## Une semaine dans les Pyrénées
+Là je décris le symptôme à un agent, il corrige, on reteste, et c'est bon. Avant, ce grain de sable aurait mangé le début des vacances, ou m'aurait convaincu de ne pas partir du tout.
 
-On est dans une maison de famille, il y a la piscine, il y a du monde, et je ne sors pas un laptop sur une table pour « juste finir un truc ». Je sors le téléphone dans la voiture, le soir quand tout le monde dort, dans les moments creux de la journée. Ce n'est pas une journée de travail déguisée : ce sont des fenêtres courtes où je lance une session dans le cloud, je regarde le résultat, et je range.
+Parce qu'en temps normal, j'aurais annulé. Je touchais tellement au but sur cette refonte que la mise en prod ne pouvait plus attendre. Cinq ans à ne jamais réussir à la terminer, et là, grâce à l'IA, elle est passée en un mois. Une fois que c'est enfin là, tu ne le remets pas à plus tard, même si de l'autre côté tout est déjà en train de s'emballer.
 
-Ça pose un vrai dilemme de déconnexion, et j'en parlerai dans un prochain article, parce que le sujet mérite mieux qu'une parenthèse. Ce que je peux dire ici, c'est qu'en temps normal j'aurais probablement annulé ces vacances. Je touchais tellement au but sur cette refonte que je traînais depuis cinq ans sans jamais réussir à la terminer, et la mise en prod ne pouvait plus attendre. Grâce à l'IA, cette refonte est passée en un mois, et du coup j'ai pu partir quand même — pas en lâchant tout à 100 %, mais en décrochant à peu près à 80 %, ce qui est déjà infiniment mieux que rester à la maison pour finir la migration pendant que tout le monde est ailleurs.
+## Des jours off, au milieu
 
-Dans ce même creux, je me suis aussi autorisé à reprendre le sujet que je remettais depuis des années : les sessions. Pas le gros event public, juste le « on se retrouve au spot » entre riders, tout de suite ou dans deux semaines parce que les gens taffent. Sur l'ancien monde WordPress, le terrain ne le permettait pas vraiment ; là le nouveau site était live, donc j'ai commencé par cadrer le produit avec Claude Code — qu'est-ce qu'on veut vraiment, éclair ou planifié, pour qui, où on s'arrête pour la V1 — plutôt que de demander à une IA de générer la feature d'un coup. En un ou deux jours on a figé « Ça ride », et surtout je l'ai fait au moment où l'énergie était là, sans attendre un sprint imaginaire au retour.
+On est dans une maison de famille dans les Pyrénées, il y a la piscine, il y a du monde, et je ne sors pas un laptop sur une table pour « juste finir un truc ». Je sors le téléphone dans la voiture, le soir quand tout le monde dort, dans les moments creux de la journée. Des fenêtres courtes : je lance un agent dans le cloud, je regarde le résultat, et je range.
 
-## À l'hôpital, sans en faire un manifeste
+Ça pose un vrai dilemme de déconnexion, et j'en parlerai dans un prochain article, parce que le sujet mérite mieux qu'une parenthèse. Ce que je peux dire ici, c'est que ces jours-là ont quand même existé. On a eu des vacances au milieu de tout ça. Pas en lâchant tout à 100 %, plutôt en décrochant à peu près à 80 %, ce qui est déjà beaucoup mieux que rester à la maison pour finir la migration pendant que tout le monde est ailleurs.
 
-Ensuite plus rien ne se passe comme prévu : contractions, maternité, naissance le 2 août, puis la néonat. La majorité du temps, on nourrit, on dort, on recommence. Je ne raconte pas ça pour dire que j'ai « shippé depuis l'hôpital » comme une performance. Je le fais quand tout le monde dort, dans les moments calmes, le même genre de fenêtres où beaucoup de gens doomscrollent ou mettent une série. Moi, dans ces moments-là, je m'amuse à prototyper et à faire avancer RideMyPark. Ce n'est ni mieux ni pire moralement ; c'est juste ce que je fais.
+Avant, le travail aurait pris la semaine entière. Là il a pris des creux, et le reste a pu rester des vacances.
 
-Avant, j'aurais culpabilisé. J'aurais ressenti de l'angoisse à l'idée de choisir entre ma fille et le travail — et même si le choix semble évident sur le papier, mon cerveau ne le traite pas toujours aussi proprement. Là, je n'ai plus vraiment à choisir de la même façon. Je peux taffer une heure dans la journée, découpée en dix petites sessions, et le produit avance comme si j'avais passé une semaine devant un PC, tout en m'occupant de ma famille, en faisant du sport, en étant présent le reste du temps.
+## L'autre monde
 
-Certes, c'est moins relaxant que tout lâcher. Mais dans certains moments on n'a pas le luxe du tout-lâcher, et l'IA m'a permis de trouver un juste milieu nettement plus avantageux pour mes proches que d'être celui qui vient en vacances (ou à l'hôpital) avec son ordinateur et qui ne joue pas vraiment avec eux.
+Ensuite plus rien ne se passe comme prévu : contractions, maternité, naissance le 2 août, puis la néonat. La majorité du temps, on nourrit, on dort, on recommence. Je ne raconte pas ça pour en faire une performance. Je le fais quand tout le monde dort, dans les moments calmes, le même genre de fenêtres où beaucoup de gens doomscrollent ou mettent une série. Moi, dans ces moments-là, je m'amuse à prototyper et à faire avancer RideMyPark. C'est juste ce que je fais.
 
-Les collègues ont testé sur le staging, il n'y a pas eu énormément de retours, et j'ai mis en production en n'allumant d'abord la feature que pour eux, histoire de voir si c'était carré sans exposer tout le monde d'un coup. Aujourd'hui je suis encore dans la boucle sur le polish — le timer d'une session à venir, ce genre de détail qui change la sensation du produit — en prenant leurs feedbacks Discord, en les donnant à Claude Code, en itérant et en retestant au fil de l'eau.
+Avant, j'aurais culpabilisé. J'aurais ressenti de l'angoisse à l'idée de choisir entre ma fille et le travail, et même si le choix semble évident sur le papier, mon cerveau ne le traite pas toujours aussi proprement. Là, je n'ai plus vraiment à choisir de la même façon. Je peux taffer une heure dans la journée, découpée en dix petits bouts, et le produit avance comme si j'avais passé une semaine devant un PC, tout en m'occupant de ma famille, en faisant du sport, en étant présent le reste du temps.
 
-## Ce que ça change pour moi
+C'est moins relaxant que tout lâcher. Mais dans certains moments on n'a pas le luxe du tout-lâcher, et l'IA m'a permis de trouver un juste milieu nettement plus avantageux pour mes proches que d'être celui qui vient avec son ordinateur et qui n'est pas vraiment là.
 
-Si je mets les étapes bout à bout, ce n'est pas une méthode à copier. C'est une suite de moments où l'exécution a cessé d'exiger que je sois collé à un bureau.
+## Après coup
 
-La migration a tenu pendant qu'on était sur la route, et le bug mobile s'est réglé sans me voler la journée. Les vacances ont eu lieu alors que j'aurais annulé, parce que cinq ans de refonte venaient enfin de basculer en un mois. Le cadrage des sessions est sorti dans le creux, pas dans un calendrier idéal. Et pendant la période la plus chargée, je n'ai pas eu à transformer chaque heure creuse en culpabilité : une heure éclatée sur la journée a suffi à faire avancer le produit sans en faire le centre de tout.
+J'ai enfin sorti une refonte que je n'arrivais pas à finir, et ma fille est née dans la foulée. Au milieu on a quand même eu des jours de vacances.
 
-Dans [Identity shift](https://tomandrieu.com/blog/identity-shift), je disais que coder n'est plus la partie difficile. Je n'avais pas encore cette preuve-là dans les mains. Maintenant si : le jugement peut tenir dans une poche, et l'exécution n'a plus besoin que je sacrifie les gens autour de moi pour avancer.
+Ce qui a rendu ça tenable, c'est que je n'avais plus besoin d'être collé à un bureau pour que ça avance. La migration a tenu pendant qu'on était sur la route. Le bug mobile s'est réglé sans me voler la journée. Les vacances ont eu lieu alors que j'aurais annulé. Et pendant la période la plus chargée, je n'ai pas eu à transformer chaque heure creuse en culpabilité.
+
+Dans [Identity shift](https://tomandrieu.com/blog/identity-shift), je disais que coder n'est plus la partie difficile. Je n'avais pas encore cette preuve-là dans les mains. Maintenant le jugement tient dans une poche, et je peux avancer RideMyPark sans poser le reste de ma vie à côté.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace the live password-private article at `blog/articles/ca-ride-telephone/` with Tom’s reframed FR/EN copy.

The slug, cover image, publish date, and password stay the same. Sessions / « Ça ride » / “ship” framing is removed from this piece (later article). `CACHE_BUST` is bumped to `2026-08-14-mondes` so the next backend image rebuild copies the new articles.

## Changes
- `blog/articles/ca-ride-telephone/index.fr.md` — *Quand mes mondes s'entrechoquent*
- `blog/articles/ca-ride-telephone/index.en.md` — *When my worlds collide* (EN “shipped” rewritten to “got out”)
- `backend/Dockerfile` — `CACHE_BUST=2026-08-14-mondes`

## Checks
- Frontmatter kept: `draft: false`, `private: true`, `visibility: password`, same `passwordHash`, `publishedAt: "2026-08-12"`, `coverImage: "cover.png"`
- Both files parse as valid YAML + markdown
- Cover and slug untouched

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3e74aba-b189-4b8a-a55f-98d233a3dc9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3e74aba-b189-4b8a-a55f-98d233a3dc9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

